### PR TITLE
Move deploy command into Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 scss ?= sass/public_analytics.css.scss
 css ?= css/public_analytics.css
 
+DEPLOY_BUCKET=18f-dap
+
 all: styles
 
 styles:
@@ -19,5 +21,5 @@ clean:
 	rm -f $(css)
 
 deploy:
-	make production && s3cmd put --recursive -P -M --add-header="Cache-Control:max-age=0" _site/* s3://18f-dap/ && s3cmd put -P --mime-type="text/css" --add-header="Cache-Control:max-age=0" _site/css/*.css s3://18f-dap/css/
+	make production && s3cmd put --recursive -P -M --add-header="Cache-Control:max-age=0" _site/* s3://$(DEPLOY_BUCKET)/ && s3cmd put -P --mime-type="text/css" --add-header="Cache-Control:max-age=0" _site/css/*.css s3://$(DEPLOY_BUCKET)/css/
 	

--- a/Makefile
+++ b/Makefile
@@ -17,3 +17,7 @@ dev:
 
 clean:
 	rm -f $(css)
+
+deploy:
+	make production && s3cmd put --recursive -P -M --add-header="Cache-Control:max-age=0" _site/* s3://18f-dap/ && s3cmd put -P --mime-type="text/css" --add-header="Cache-Control:max-age=0" _site/css/*.css s3://18f-dap/css/
+	

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ To deploy this app to `analytics.usa.gov`, you will need authorized access to 18
 To deploy the site using `s3cmd`, production settings, and a **5 minute cache time**, run:
 
 ```bash
-make production && s3cmd put --recursive -P -M --add-header="Cache-Control:max-age=0" _site/* s3://18f-dap/ && s3cmd put -P --mime-type="text/css" --add-header="Cache-Control:max-age=0" _site/css/*.css s3://18f-dap/css/
+make deploy
 ```
 
 **Use the full command above.** The full command ensures that the build completes successfully, with production settings, _before_ triggering an upload to the production bucket.


### PR DESCRIPTION
This moves the (rather complicated) `s3cmd` deploy command into the `Makefile` to make the new deploy command `make deploy`. It is hardcoded to GSA/18F's specific S3 bucket, with `s3cmd`-specific parameters.