### PR TITLE
Create a staging site at pages.18f.gov

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,3 +84,5 @@ This project is in the worldwide [public domain](LICENSE.md). As stated in [CONT
 > This project is in the public domain within the United States, and copyright and related rights in the work worldwide are waived through the [CC0 1.0 Universal public domain dedication](https://creativecommons.org/publicdomain/zero/1.0/).
 >
 > All contributions to this project will be released under the CC0 dedication. By submitting a pull request, you are agreeing to comply with this waiver of copyright interest.
+
+

--- a/_config_18f_pages.yml
+++ b/_config_18f_pages.yml
@@ -1,0 +1,5 @@
+
+# The staging site uses 18F Pages, a prefix, and pulls from production data.
+url: https://pages.18f.gov/analytics.usa.gov
+baseurl: /analytics.usa.gov
+data_url: https://analytics.usa.gov/data/live

--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@ permalink: /
     <meta http-equiv="X-UA-Compatible" content="IE=Edge">
     <meta name="google-site-verification" content="NjbZn6hQe7OwV-nTsa6nLmtrOUcSGPRyFjxm5zkmCcg" />
 
-    <link rel="stylesheet" href="/css/public_analytics.css">
+    <link rel="stylesheet" href="{{ site.baseurl }}/css/public_analytics.css">
 
     <meta name="twitter:site" content="@{{ site.twitter }}">
     <meta name="twitter:creator" content="@{{ site.twitter }}">
@@ -49,7 +49,7 @@ permalink: /
 
     <meta name="twitter:card" content="summary_large_image">
     <meta property="og:image" content="{{ site.url }}/images/share-image.png" />
-    <script src="/js/vendor/d3.v3.min.js"></script>
+    <script src="{{ site.baseurl }}/js/vendor/d3.v3.min.js"></script>
 
     <script>
     (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
@@ -88,13 +88,13 @@ permalink: /
 
 
     <!--[if lte IE 9]>
-    <script src="/js/vendor/aight.v2.min.js"></script>
+    <script src="{{ site.baseurl }}/js/vendor/aight.v2.min.js"></script>
     <![endif]-->
     
-    <script src="/js/vendor/q.min.js"></script>
+    <script src="{{ site.baseurl }}/js/vendor/q.min.js"></script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <link href="/css/google-fonts.css" rel="stylesheet" />
+    <link href="{{ site.baseurl }}/css/google-fonts.css" rel="stylesheet" />
   </head>
 
   <body>
@@ -356,7 +356,7 @@ permalink: /
     window._ie = window._ie9 || window._ie10 || window._ie11;
   </script>
 
-  <script src="/js/index.js"></script>
+  <script src="{{ site.baseurl }}/js/index.js"></script>
 
   <!-- report to oneself -->
   <script id="_fed_an_ua_tag" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=GSA&exts=json"></script>


### PR DESCRIPTION
This uses 18F Pages to give us a staging site, visible right now at https://pages.18f.gov/analytics.usa.gov/.

* I made every URL in the app that pulls assets support a Jekyll `baseurl` for a path prefix.
* I added a `_config_18f_pages.yml` file, a Jekyll settings override file whose filename 18F Pages looks for and will use if present. It sets the `baseurl`, site `url`, and `data_url` for live data.
* Because we store data in S3, not version control, **the staging site uses production data** -- and so the staging site is really only appropriate for previewing front-end changes.

Rather than change our ongoing workflow, I think we should continue developing on `master`, and push the latest stuff or WIP branch over to `18f-pages` whenever we need a public staging URL to share with people.

Fixes #220.