### PR TITLE
[WIP] use Web Design Standard colors

### DIFF
--- a/css/public_analytics.scss
+++ b/css/public_analytics.scss
@@ -178,6 +178,7 @@ section {
     height: 2.5rem;
     margin-bottom: 0;
   }
+
   h4 {
     display: block;
     text-align: right;
@@ -189,7 +190,7 @@ section {
 
 #secondary_data {
   @include span-columns(5);
-  @include media($small-screen)  {
+  @include media($small-screen) {
     @include span-columns(1);
     border-top: 1px solid $gray;
     border-left: none;
@@ -204,16 +205,20 @@ section {
   }
 }
 
-#explanation, #data_download, #agencies {
+#explanation,
+#data_download,
+#agencies {
   border-top: $border_width solid $gray;
   font-size: 90%;
   line-height: 1.6em;
+
   li {
     margin: 1em 0;
   }
 }
 
-#explanation, #agencies {
+#explanation,
+#agencies {
   @include span-columns(9);
 
   @include media($small-screen)  {
@@ -296,10 +301,12 @@ section {
     font-size: 4em;
   }
 
-  h1, h2 {
+  h1,
+  h2 {
     text-align: center;
     font-weight: 300;
   }
+
   h2 {
     font-size: 2em;
     margin: 2em auto;
@@ -311,7 +318,7 @@ section {
   }
 }
 
-.bar:focus{
+.bar:focus {
   outline: 0;
 }
 

--- a/css/public_analytics.scss
+++ b/css/public_analytics.scss
@@ -425,11 +425,12 @@ ul.pills {
     font-size: 80%;
 
     .bin {
-      margin-left: 2em;
+      margin-left: 1em;
       margin-bottom: 0rem;
 
       .bar {
-        display: none;
+        // display: none;
+        height: 3px;
       }
     }
   }

--- a/css/public_analytics.scss
+++ b/css/public_analytics.scss
@@ -542,3 +542,33 @@ figure figure {
     opacity: .8;
   }
 }
+
+#devices .bar-chart {
+  .bar {
+    background: $usa-secondary;
+  }
+
+  .bar-chart .bar {
+    background: $usa-secondary-light;
+  }
+}
+
+#browsers .bar-chart {
+  .bar {
+    background: $usa-green;
+  }
+
+  .bar-chart .bar {
+    background: $usa-green-light;
+  }
+}
+
+#operating_systems .bar-chart {
+  .bar {
+    background: $usa-gold;
+  }
+
+  .bar-chart .bar {
+    background: $usa-gold-light;
+  }
+}

--- a/css/public_analytics.scss
+++ b/css/public_analytics.scss
@@ -3,13 +3,17 @@
 ---
 @import "bourbon/bourbon";
 
-//Grid Settings:
+// Grid Settings:
 $grid-columns: 14;
 $max-width: em(1560);
 $gutter: 0em !global;
 
 @import "neat/neat";
 
+$xlarge-screen: new-breakpoint(max-width  1600px  14);
+$large-screen:  new-breakpoint(max-width  1200px  14);
+$medium-screen: new-breakpoint(max-width  992px   14);
+$small-screen:  new-breakpoint(max-width  768px   1);
 
 @mixin responsive_container {
   @include outer-container;
@@ -28,31 +32,12 @@ $gutter: 0em !global;
   }
 }
 
-$xlarge-screen: new-breakpoint(max-width  1600px  14);
-$large-screen:  new-breakpoint(max-width  1200px  14);
-$medium-screen: new-breakpoint(max-width  992px   14);
-$small-screen:  new-breakpoint(max-width  768px   1);
-
 // Fonts & Colors:
+@import 'colors';
 
-$red: #921B1E;
-$blue: #022945;
-$light_gray: #f9f9f9;
-
-// used only for borders
-$gray: #e4e4e4;
-
-$dark_gray: #222;
-$light_blue: #3A96B7;
-$dark_blue: #36435A;
-$white: #fff;
-$background_color: $light_gray;
-$container_background: $white;
 $border_width: 1px;
 
 $bold_weight: 600;
-
-$data: $light_blue;
 
 // Other Setup:
 $border_radius: 5px;
@@ -109,12 +94,8 @@ header {
 
   .header_container {
     @include responsive_container;
+    border-bottom: 6px solid $medium_blue;
     padding: 0 1em;
-  }
-
-  #color_bar {
-    background: $light_blue;
-    height: 6px;
   }
 
   h1 {
@@ -418,7 +399,7 @@ ul.pills {
 
       &[aria-selected='true'] {
         color: #fff;
-        background: $light_blue;
+        background: $medium_blue;
       }
     }
 

--- a/index.html
+++ b/index.html
@@ -98,7 +98,6 @@ permalink: /
         <h1>analytics<a href="http://www.usa.gov" class="external-link">.usa.gov</a></h1>
         <a id="about" href="#explanation" class="site-nav">About this site</a>
       </div>
-      <div id="color_bar"></div>
     </header>
 
     <div class="container">

--- a/sass/_colors.scss
+++ b/sass/_colors.scss
@@ -1,0 +1,53 @@
+$white: #fff;
+
+// US Web Design Standard colors
+$usa-gray-dark: #323a45;
+$usa-gray: #5b616b;
+
+$usa-gray-light: #aeb0b5;
+$usa-gray-lighter: #d6d7d9;
+$usa-gray-lightest: #f1f1f1;
+
+$usa-primary-darkest: #112e51;
+
+$usa-gold: #fdb81e;
+$usa-gold-light: #f9c642;
+$usa-gold-lighter: #fad980;
+
+$usa-green: #2e8540;
+$usa-green-light: #4aa564;
+$usa-green-lighter: #94bfa2;
+
+$usa-cool-blue: #205493;
+$usa-cool-blue-light: #4773aa;
+$usa-cool-blue-lighter: #8ba6ca;
+
+$usa-primary: #02bfe7;
+$usa-primary-alt-darkest: #046b99;
+$usa-primary-alt-dark: #00a6d2;
+$usa-primary-alt-light: #9bdaf1;
+$usa-primary-alt-lightest: #e1f3f8;
+
+$usa-secondary: #e31c3d;
+$usa-secondary-darkest: #981b1e;
+$usa-secondary-dark: #cd2026;
+$usa-secondary-light: #e59393;
+$usa-secondary-lightest: #f9dede;
+
+// colors aliases
+$red: $usa-secondary;
+$blue: $usa-primary;
+$light_gray: $usa-gray-light;
+
+// used only for borders
+$gray: #e4e4e4;
+
+$dark_gray: $usa-gray-dark;
+$light_blue: $usa-primary-alt-light;
+$medium_blue: $usa-primary-alt-dark;
+$dark_blue: $usa-primary-darkest;
+
+$background_color: $light_gray;
+$container_background: $white;
+
+$data: $medium_blue;


### PR DESCRIPTION
#### :construction: Work in Progress :construction: 

This PR breaks our colors out into a separate SCSS import (`sass/_colors.scss`) and brings in the [US Web Design Standards palette](https://playbook.cio.gov/designstandards/visual-style/#palette), with all color variables namespaced by the `usa-` prefix.

I swapped out our blues for theirs as a first step, which was pretty painless. The main goal of this experiment, though, was to see whether we could use different colors for each data types to break up the monotony of the blue bars. Here's what it looks like right now:

![image](https://cloud.githubusercontent.com/assets/113896/10742860/b06e8962-7bec-11e5-8132-05a5de5e0206.png)

I'm not 100% sold on this color selection right now, because I think it looks a little too googly:

![image](https://cloud.githubusercontent.com/assets/113896/10742937/3897f1fc-7bed-11e5-8d92-6077d926dd63.png)
