### PR TITLE
Revamp open data on analytics.usa.gov

### DIFF
--- a/css/public_analytics.scss
+++ b/css/public_analytics.scss
@@ -231,6 +231,18 @@ section {
   border-top: $border_width solid $gray;
   line-height: 1.6;
 
+  h4 {font-size: 90%}
+
+  ul {
+    font-size: 80%;
+    padding: 0;
+  }
+
+  ul, li {
+    list-style-type: none;
+    list-style-position: inside;
+  }
+
   li {
     margin: 1em 0;
   }
@@ -245,7 +257,7 @@ section {
 }
 
 #data_download {
-  @include span-columns(9);
+  @include span-columns(5);
   @include media($small-screen)  {
     @include span-columns(1);
   }
@@ -274,34 +286,6 @@ section {
 .three_column {
   @include span-columns(3 of 9);
   
-  @include media($small-screen)  {
-    @include span-columns(1);
-    border-left: none;
-    border-top: 1px solid $gray;
-  }
-  h4 {
-    text-align: center;
-    margin: 0;
-    font-size: 90%;
-  }
-  h5 {
-    margin-top: 0;
-    text-align: center;
-  }
-}
-
-.data_column {
-  @include span-columns(4 of 9);
-
-  ul {
-    font-size: 80%;
-  }
-
-  ul, li {
-    list-style-type: none;
-    list-style-position: inside;
-  }
-
   @include media($small-screen)  {
     @include span-columns(1);
     border-left: none;

--- a/css/public_analytics.scss
+++ b/css/public_analytics.scss
@@ -227,10 +227,8 @@ section {
 }
 
 #explanation,
-#data_download,
-#agencies {
+#data_download {
   border-top: $border_width solid $gray;
-  font-size: 90%;
   line-height: 1.6;
 
   li {
@@ -238,7 +236,7 @@ section {
   }
 }
 
-#explanation, #agencies {
+#explanation {
   @include span-columns(9);
 
   @include media($small-screen)  {
@@ -247,10 +245,12 @@ section {
 }
 
 #data_download {
-  @include span-columns(5);
+  @include span-columns(9);
   @include media($small-screen)  {
     @include span-columns(1);
   }
+
+
 }
 
 .section_headline {
@@ -273,7 +273,34 @@ section {
 
 .three_column {
   @include span-columns(3 of 9);
-  // border-left: 1px solid $gray;
+  
+  @include media($small-screen)  {
+    @include span-columns(1);
+    border-left: none;
+    border-top: 1px solid $gray;
+  }
+  h4 {
+    text-align: center;
+    margin: 0;
+    font-size: 90%;
+  }
+  h5 {
+    margin-top: 0;
+    text-align: center;
+  }
+}
+
+.data_column {
+  @include span-columns(4 of 9);
+
+  ul {
+    font-size: 80%;
+  }
+
+  ul, li {
+    list-style-type: none;
+    list-style-position: inside;
+  }
 
   @include media($small-screen)  {
     @include span-columns(1);

--- a/css/public_analytics.scss
+++ b/css/public_analytics.scss
@@ -184,7 +184,6 @@ section {
 }
 
 #main_data {
-  border-right: 1px solid $gray;
 
   @include span-columns(9);
   @include media($small-screen)  {
@@ -209,6 +208,8 @@ section {
 }
 
 #secondary_data {
+  border-left: 1px solid $gray;
+
   @include span-columns(5);
   @include media($small-screen)  {
     @include span-columns(1);

--- a/index.html
+++ b/index.html
@@ -293,7 +293,7 @@ permalink: /
         <section id="top_downloads_table">
 
           <h3>Top 10 Downloads</h3>
-            <h5><em>Total file downloads over the last week on government domains.</em></h5>
+          <h5><em>Total file downloads over the last week on government domains.</em></h5>
           <figure id="top-downloads" 
             data-block="top-downloads"
             data-source="{{ site.data_url }}/top-downloads-7-days.json">
@@ -305,96 +305,58 @@ permalink: /
       </div>
 
       <section id="data_download">
-        <h3>Download the Data</h3>
+        
+        <section class="section_subheadline">
+          Download the data.
+        </section>
 
-        <p>
-          You can download the data that powers the charts above, in JSON format.
-        </p>
+        <section class="data_column">
+          <h4>Updated daily (CSV)</h4>
+          <ul>
+            <li>
+              <a href="{{ site.data_url }}/all-domains-30-days.csv" class="download-data">Visits to all domains over 30 days</a>
+            </li>
+            <li>
+              <a href="{{ site.data_url }}/top-downloads-7-days.csv" class="download-data">Top downloads over 7 days</a>
+            </li>
+            <li>
+              <a href="{{ site.data_url }}/devices.csv" class="download-data">Desktop/mobile/tablet</a>
+            </li>
+            <li>
+              <a href="{{ site.data_url }}/browsers.csv" class="download-data">Web browsers</a>
+            </li>
+            <li>
+              <a href="{{ site.data_url }}/ie.csv" class="download-data">Versions of Internet Explorer</a>
+            </li>
+            <li>
+              <a href="{{ site.data_url }}/os.csv" class="download-data">Operating systems</a>
+            </li>
+            <li>
+              <a href="{{ site.data_url }}/windows.csv" class="download-data">Versions of Windows</a>
+            </li>
+          </ul>
+        </section>
 
-        <ul>
-          <li>
-            <a href="{{ site.data_url }}/realtime.json" class="download-data">
-              People online right now</a>
-            (Updated every minute)
-          </li>
-          <li>
-            <a href="{{ site.data_url }}/all-pages-realtime.json" class="download-data">
-              People visiting each site, right now</a>
-            (Updated every minute)
-          </li>
-          <li>
-            <a href="{{ site.data_url }}/today.json" class="download-data">
-              Visits every hour today</a>
-            (Updated every hour)
-          </li>
-          <li>
-            <a href="{{ site.data_url }}/all-domains-30-days.json" class="download-data">
-              Visits to each site over the last 30 days</a>
-            (Updated every day)
-          </li>
-          <li>
-            <a href="{{ site.data_url }}/devices.json" class="download-data">
-              Visits by desktop/mobile/tablet devices over 90 days</a>
-            (Updated every day)
-          </li>
-          <li>
-            <a href="{{ site.data_url }}/os.json" id="visits" class="download-data">
-              Visits broken down by Operating System over 90 days</a>
-            (Updated every day)
-          </li>
-          <li>
-            <a href="{{ site.data_url }}/windows.json" class="download-data">
-              Visits broken down by Windows version over 90 days</a>
-            (Updated every day)
-          </li>
-          <li>
-            <a href="{{ site.data_url }}/browsers.json" class="download-data">
-              Visits broken down by browser over 90 days</a>
-            (Updated every day)
-          </li>
-          <li>
-            <a href="{{ site.data_url }}/ie.json" class="download-data">
-              Visits broken down by Internet Explorer version over 90 days</a>
-            (Updated every day)
-          </li>
-          <li>
-            <a href="{{ site.data_url }}/top-cities-90-days.json" class="download-data">
-              Visits broken down by city over 90 days</a>
-            (Updated every day)
-          </li>
-          <li>
-            <a href="{{ site.data_url }}/top-countries-90-days.json" class="download-data">
-              Visits broken down by country over 90 days</a>
-            (Updated every day)
-          </li>
-          <li>
-            <a href="{{ site.data_url }}/top-pages-realtime.json" class="download-data">
-              Top 20 pages, ranked by visitors online now</a>
-            (Updated every minute)
-          </li>
-          <li>
-            <a href="{{ site.data_url }}/top-domains-7-days.json" class="download-data">
-              Top 20 domains, ranked by visits over 7 days</a>
-            (Updated every day)
-          </li>
-          <li>
-            <a href="{{ site.data_url }}/top-domains-30-days.json" class="download-data">
-              Top 20 domains, ranked by visits over 30 days</a>
-            (Updated every day)
-          </li>
-          <li>
-            <a href="{{ site.data_url }}/top-downloads-realtime.json" class="download-data">
-              Top 100 downloads right now</a>
-            (Updated every minute)
-          </li>
-          <li>
-            <a href="{{ site.data_url }}/top-downloads-30-days.json" class="download-data">
-              Top 100 downloads over 30 days</a>
-            (Updated every day)
-          </li>
-        </ul>
+        <section class="data_column">
+          <h4>Updated every minute</h4>
+
+          <ul>
+            <li>
+              <a href="{{ site.data_url }}/all-pages-realtime.csv" class="download-data">All pages people are visiting</a> (CSV)
+            </li>
+            <li>
+              <a href="{{ site.data_url }}/top-countries-realtime.json" class="download-data">Visitors per country</a> (JSON)
+            </li>
+            <li>
+              <a href="{{ site.data_url }}/top-cities-realtime.json" class="download-data">Visitors per city</a> (JSON)
+            </li>
+            <li>
+              <a href="{{ site.data_url }}/realtime.json" class="download-data">Total people online</a> (JSON)
+            </li>
+          </ul>
+
+        </section>
       </section>
-
       <section id="explanation">
 
         <h3>About this Site</h3>

--- a/index.html
+++ b/index.html
@@ -304,29 +304,6 @@ permalink: /
         </section>
       </div>
 
-      <section id="explanation">
-        <h3>About this Site</h3>
-        <p>
-          This data provides a window into how people are interacting with the government online. The data comes from a unified Google Analytics account for U.S. federal government agencies known as the <a href="https://www.digitalgov.gov/services/dap/" class="external-link">Digital Analytics Program</a>. This program helps government agencies understand how people find, access, and use government services online. The program <a href="https://www.digitalgov.gov/services/dap/common-questions-about-dap-faq/#part-4" class="external-link">does not track individuals</a>, and <a href="https://support.google.com/analytics/answer/2763052?hl=en" class="external-link">anonymizes the IP addresses</a> of visitors.
-        </p>
-
-        <p>
-          Not every government website is represented in this data. Currently, the Digital Analytics Program collects web traffic from around <a href="https://analytics.usa.gov/data/live/second-level-domains.csv" class="external-link">400 executive branch government domains</a>, across <a href="https://analytics.usa.gov/data/sites.csv" class="external-link">over 4000 total websites</a>, including every cabinet department. We continue to pursue and add more sites frequently; to add your site, <a href="mailto:DAP@support.digitalgov.gov" class="external-link">email the Digital Analytics Program</a>.
-        </p>
-
-        <p>
-          <strong>Top 20 data:</strong> "Now" data includes traffic to a specific, single page&mdash;whereas "7 Days" and "30 Days" data includes traffic to a domain <strong>and</strong> all pages within that domain.
-        </p>
-
-        <p>
-          This open source project is in the public domain, which means that this website and its data are free for you to use without restriction. You can find the <a href="https://github.com/GSA/analytics.usa.gov" class="external-link">code for this website</a> and the <a href="https://github.com/18F/analytics-reporter" class="external-link">code behind the data collection</a> on GitHub.
-        </p>
-
-        <p>
-          We plan to expand the data made available here. If you have any suggestions, or spot any issues or bugs, please <a href="https://github.com/GSA/analytics.usa.gov/issues" class="external-link">open an issue on GitHub</a> or contact the <a href="mailto:DAP@support.digitalgov.gov" class="external-link">Digital Analytics Program</a>.
-        </p>
-      </section>
-
       <section id="data_download">
         <h3>Download the Data</h3>
 
@@ -417,6 +394,32 @@ permalink: /
           </li>
         </ul>
       </section>
+
+      <section id="explanation">
+
+        <h3>About this Site</h3>
+        <p>
+          This data provides a window into how people are interacting with the government online. The data comes from a unified Google Analytics account for U.S. federal government agencies known as the <a href="https://www.digitalgov.gov/services/dap/" class="external-link">Digital Analytics Program</a>. This program helps government agencies understand how people find, access, and use government services online. The program <a href="https://www.digitalgov.gov/services/dap/common-questions-about-dap-faq/#part-4" class="external-link">does not track individuals</a>, and <a href="https://support.google.com/analytics/answer/2763052?hl=en" class="external-link">anonymizes the IP addresses</a> of visitors.
+        </p>
+
+        <p>
+          Not every government website is represented in this data. Currently, the Digital Analytics Program collects web traffic from around <a href="https://analytics.usa.gov/data/live/second-level-domains.csv" class="external-link">400 executive branch government domains</a>, across <a href="https://analytics.usa.gov/data/sites.csv" class="external-link">over 4000 total websites</a>, including every cabinet department. We continue to pursue and add more sites frequently; to add your site, <a href="mailto:DAP@support.digitalgov.gov" class="external-link">email the Digital Analytics Program</a>.
+        </p>
+
+        <p>
+          <strong>Top 20 data:</strong> "Now" data includes traffic to a specific, single page&mdash;whereas "7 Days" and "30 Days" data includes traffic to a domain <strong>and</strong> all pages within that domain.
+        </p>
+
+        <p>
+          This open source project is in the public domain, which means that this website and its data are free for you to use without restriction. You can find the <a href="https://github.com/GSA/analytics.usa.gov" class="external-link">code for this website</a> and the <a href="https://github.com/18F/analytics-reporter" class="external-link">code behind the data collection</a> on GitHub.
+        </p>
+
+        <p>
+          We plan to expand the data made available here. If you have any suggestions, or spot any issues or bugs, please <a href="https://github.com/GSA/analytics.usa.gov/issues" class="external-link">open an issue on GitHub</a> or contact the <a href="mailto:DAP@support.digitalgov.gov" class="external-link">Digital Analytics Program</a>.
+        </p>
+      </section>
+
+      
 
     </div>
   </body>

--- a/index.html
+++ b/index.html
@@ -264,8 +264,10 @@ permalink: /
             data-block="top-pages-realtime"
             data-source="{{ site.data_url }}/top-pages-realtime.json"
             data-refresh="15">
-            <h5><strong>Pages</strong><br/>
-            <em>People on a single, specific government page now.</em></h5>
+            <h5><em>
+              People on a <strong>single, specific page</strong> now.
+              <a href="{{ site.data_url }}/all-pages-realtime.csv">Download the full dataset.</a>
+            </em></h5>
             <div class="data bar-chart">
             </div>
           </figure>
@@ -273,8 +275,7 @@ permalink: /
           <figure class="top-pages" id="top-pages-7-days" role="tabpanel"
             data-block="top-pages"
             data-source="{{ site.data_url }}/top-domains-7-days.json">
-            <h5><strong>Domains</strong><br/>
-            <em>Total visits over the last week to government domains, which includes traffic to all pages within that domain.</em></h5>
+            <h5><em>Total visits over the last week to <strong>domains</strong>, including traffic to all pages within that domain.</em></h5>
             <div class="data bar-chart">
             </div>
           </figure>
@@ -282,8 +283,10 @@ permalink: /
           <figure class="top-pages" id="top-pages-30-days" role="tabpanel"
             data-block="top-pages"
             data-source="{{ site.data_url }}/top-domains-30-days.json">
-            <h5><strong>Domains</strong><br/>
-              <em>Total visits over the last month to government domains, which includes traffic to all pages within that domain.</em></h5>
+            <h5><em>
+              Visits over the last month to <strong>domains</strong>, including traffic to all pages within that domain.
+              <a href="{{ site.data_url }}/top-domains-30-days.csv">Download the full dataset.</a>
+            </em></h5>
             <div class="data bar-chart">
             </div>
           </figure>
@@ -304,59 +307,6 @@ permalink: /
         </section>
       </div>
 
-      <section id="data_download">
-        
-        <section class="section_subheadline">
-          Download the data.
-        </section>
-
-        <section class="data_column">
-          <h4>Updated daily (CSV)</h4>
-          <ul>
-            <li>
-              <a href="{{ site.data_url }}/all-domains-30-days.csv" class="download-data">Visits to all domains over 30 days</a>
-            </li>
-            <li>
-              <a href="{{ site.data_url }}/top-downloads-7-days.csv" class="download-data">Top downloads over 7 days</a>
-            </li>
-            <li>
-              <a href="{{ site.data_url }}/devices.csv" class="download-data">Desktop/mobile/tablet</a>
-            </li>
-            <li>
-              <a href="{{ site.data_url }}/browsers.csv" class="download-data">Web browsers</a>
-            </li>
-            <li>
-              <a href="{{ site.data_url }}/ie.csv" class="download-data">Versions of Internet Explorer</a>
-            </li>
-            <li>
-              <a href="{{ site.data_url }}/os.csv" class="download-data">Operating systems</a>
-            </li>
-            <li>
-              <a href="{{ site.data_url }}/windows.csv" class="download-data">Versions of Windows</a>
-            </li>
-          </ul>
-        </section>
-
-        <section class="data_column">
-          <h4>Updated every minute</h4>
-
-          <ul>
-            <li>
-              <a href="{{ site.data_url }}/all-pages-realtime.csv" class="download-data">All pages people are visiting</a> (CSV)
-            </li>
-            <li>
-              <a href="{{ site.data_url }}/top-countries-realtime.json" class="download-data">Visitors per country</a> (JSON)
-            </li>
-            <li>
-              <a href="{{ site.data_url }}/top-cities-realtime.json" class="download-data">Visitors per city</a> (JSON)
-            </li>
-            <li>
-              <a href="{{ site.data_url }}/realtime.json" class="download-data">Total people online</a> (JSON)
-            </li>
-          </ul>
-
-        </section>
-      </section>
       <section id="explanation">
 
         <h3>About this Site</h3>
@@ -381,6 +331,53 @@ permalink: /
         </p>
       </section>
 
+      <section id="data_download">
+        
+        <h3>Download the Data</h3>
+
+          <h4>Updated daily (CSV)</h4>
+          <ul>
+            <li>
+              <a href="{{ site.data_url }}/all-domains-30-days.csv" class="download-data">Visits to all domains over 30 days</a>
+            </li>
+            <li>
+              <a href="{{ site.data_url }}/top-downloads-7-days.csv" class="download-data">Top downloads over 7 days</a>
+            </li>
+            <li>
+              <a href="{{ site.data_url }}/devices.csv" class="download-data">Desktop/mobile/tablet</a>
+            </li>
+            <li>
+              <a href="{{ site.data_url }}/browsers.csv" class="download-data">Web browsers</a>
+            </li>
+            <li>
+              <a href="{{ site.data_url }}/ie.csv" class="download-data">Versions of Internet Explorer</a>
+            </li>
+            <li>
+              <a href="{{ site.data_url }}/os.csv" class="download-data">Operating systems</a>
+            </li>
+            <li>
+              <a href="{{ site.data_url }}/windows.csv" class="download-data">Versions of Windows</a>
+            </li>
+          </ul>
+          <h4>Updated every minute</h4>
+
+          <ul>
+            <li>
+              <a href="{{ site.data_url }}/all-pages-realtime.csv" class="download-data">All pages people are visiting</a> (CSV)
+            </li>
+            <li>
+              <a href="{{ site.data_url }}/top-countries-realtime.json" class="download-data">Visitors per country</a> (JSON)
+            </li>
+            <li>
+              <a href="{{ site.data_url }}/top-cities-realtime.json" class="download-data">Visitors per city</a> (JSON)
+            </li>
+            <li>
+              <a href="{{ site.data_url }}/realtime.json" class="download-data">Total people online</a> (JSON)
+            </li>
+          </ul>
+
+        </section>
+      </section>
       
 
     </div>


### PR DESCRIPTION
This breaks out the data section into a more full-width presentation, with two columns. It links to more CSVs and better data, and drops the direct links to every JSON file. It looks better in some ways, and makes the flow of the page worse in others.

There's other work besides the presentation here -- the work to slim/modify reports in https://github.com/18F/analytics-reporter/pull/124 supports this PR, and some other production server cron-rejiggering was done to make sure we're within quotas, and publishing all the CSVs we want.

This new open data pane emphasizes CSV for nearly everything. We could add JSON links to many things pretty easily. 

Here's a screenshot of what it looks like on this branch - I would love some love from @JuliaWinn and @shawnbot to make this feel better and more integrated into the app.

![testing](https://cloud.githubusercontent.com/assets/4592/10812877/c92a41fc-7df0-11e5-8480-b061b97c597e.png)

I also added direct links to the bulk data from the top-most panes, and tried removing the extra bolded "Domains" and "Pages" headers and instead bolding those words within the descriptive area. So they look like:

![screenshot from 2015-10-29 04-04-32](https://cloud.githubusercontent.com/assets/4592/10813051/58207da8-7df2-11e5-8b59-638e1c16f708.png)

And:

![screenshot from 2015-10-29 04-04-38](https://cloud.githubusercontent.com/assets/4592/10813052/5ae5ed52-7df2-11e5-8c74-83d6be23c6e4.png)

This really makes me feel like we should have made a full dataset for the 7-day report, or that we should just drop the 7-day report and replace it with something else (like the downloads tab! I think we can make it work!). But that's for another day.

Fixes #214.