### PR TITLE
Make "top ____" tables consistent in display

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,12 +5,6 @@ DEPLOY_BUCKET=18f-dap
 
 all: styles
 
-styles:
-	sass $(scss):$(css)
-
-watch:
-	sass --watch $(scss):$(css)
-
 production:
 	bundle exec jekyll build
 
@@ -22,4 +16,4 @@ clean:
 
 deploy:
 	make production && s3cmd put --recursive -P -M --add-header="Cache-Control:max-age=0" _site/* s3://$(DEPLOY_BUCKET)/ && s3cmd put -P --mime-type="text/css" --add-header="Cache-Control:max-age=0" _site/css/*.css s3://$(DEPLOY_BUCKET)/css/
-	
+

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,10 @@
-scss ?= sass/public_analytics.css.scss
-css ?= css/public_analytics.css
-
 DEPLOY_BUCKET=18f-dap
-
-all: styles
 
 production:
 	bundle exec jekyll build
 
 dev:
 	bundle exec jekyll serve --watch --config=_config.yml,_development.yml
-
-clean:
-	rm -f $(css)
 
 deploy:
 	make production && s3cmd put --recursive -P -M --add-header="Cache-Control:max-age=0" _site/* s3://$(DEPLOY_BUCKET)/ && s3cmd put -P --mime-type="text/css" --add-header="Cache-Control:max-age=0" _site/css/*.css s3://$(DEPLOY_BUCKET)/css/

--- a/css/public_analytics.scss
+++ b/css/public_analytics.scss
@@ -285,7 +285,7 @@ section {
 
 .three_column {
   @include span-columns(3 of 9);
-  
+
   @include media($small-screen)  {
     @include span-columns(1);
     border-left: none;
@@ -371,6 +371,18 @@ section {
 #top_100_table {
   h3 {
     @include span-columns(2 of 5);
+  }
+}
+
+#top_downloads_table {
+  h5 {
+    margin-top: 10px;
+  }
+}
+
+#top_100_table, #top_downloads_table {
+  h3 {
+    font-size: 1.0em;
   }
   h5 {
     color: $dark_gray;

--- a/index.html
+++ b/index.html
@@ -63,7 +63,7 @@ permalink: /
     ga('set', 'forceSSL', true);
     ga('send', 'pageview');
 
-    document.addEventListener("DOMContentLoaded", function(event) { 
+    document.addEventListener("DOMContentLoaded", function(event) {
 
       d3.selectAll('.download-data').on('click', function() {
         var link = this.href;
@@ -95,7 +95,7 @@ permalink: /
     <!--[if lte IE 9]>
     <script src="{{ site.baseurl }}/js/vendor/aight.v2.min.js"></script>
     <![endif]-->
-    
+
     <script src="{{ site.baseurl }}/js/vendor/q.min.js"></script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
@@ -217,7 +217,7 @@ permalink: /
         <section class="section_headline">
           <h3>Visitor Locations Right Now</h3>
         </section>
-        
+
         <section id="cities" class="three_column"
           data-block="cities"
           data-source="{{ site.data_url }}/top-cities-realtime.json">
@@ -253,11 +253,11 @@ permalink: /
         <section id="top_100_table">
 
           <!-- see: http://heydonworks.com/practical_aria_examples/ -->
-          <h3>Top 20</h3>
+          <h3>Top <span id="top_table_type">Pages</span></h3>
           <ul class="pills" role="tablist">
-            <li><a role="tab" aria-selected="true" href="#top-pages-realtime" class="site-nav">Now</a></li>
-            <li><a role="tab" href="#top-pages-7-days" class="site-nav">7 Days</a></li>
-            <li><a role="tab" href="#top-pages-30-days" class="site-nav">30 Days</a></li>
+            <li><a role="tab" data-type="Pages" aria-selected="true" href="#top-pages-realtime" class="site-nav">Now</a></li>
+            <li><a role="tab" data-type="Domains" href="#top-pages-7-days" class="site-nav">7 Days</a></li>
+            <li><a role="tab" data-type="Domains" href="#top-pages-30-days" class="site-nav">30 Days</a></li>
           </ul>
 
           <figure class="top-pages" id="top-pages-realtime" role="tabpanel"
@@ -295,15 +295,15 @@ permalink: /
 
         <section id="top_downloads_table">
 
-          <h3>Top 10 Downloads</h3>
+          <h3>Top Downloads</h3>
           <h5><em>Total file downloads over the last week on government domains.</em></h5>
-          <figure id="top-downloads" 
+          <figure id="top-downloads"
             data-block="top-downloads"
             data-source="{{ site.data_url }}/top-downloads-7-days.json">
             <div class="data bar-chart">
             </div>
           </figure>
-        
+
         </section>
       </div>
 
@@ -332,7 +332,7 @@ permalink: /
       </section>
 
       <section id="data_download">
-        
+
         <h3>Download the Data</h3>
 
           <h4>Updated daily (CSV)</h4>
@@ -378,7 +378,7 @@ permalink: /
 
         </section>
       </section>
-      
+
 
     </div>
   </body>

--- a/js/index.js
+++ b/js/index.js
@@ -225,7 +225,7 @@
         });
         var international = total_visits - us_visits;
         var data = {
-          "United States": us_visits, 
+          "United States": us_visits,
           "International": international
         };
         return addShares(listify(data));
@@ -238,7 +238,7 @@
       ),
     "international_visits": renderBlock()
       .transform(function(d) {
-        var countries = addShares(d.data, function(d){ return d.active_visitors; });        
+        var countries = addShares(d.data, function(d){ return d.active_visitors; });
         countries = countries.filter(function(c) {
           return c.country != "United States";
         });
@@ -258,7 +258,7 @@
       .render(
         barChart()
           .value(function(d) { return +d.total_events; })
-          .label(function(d) { 
+          .label(function(d) {
             return [
               '<span class="name"><a class="top-download-page" target="_blank" href=http://', d.page, '>', d.page_title, '</a></span> ',
               '<span class="domain" >', formatURL(d.page), '</span> ',
@@ -413,7 +413,8 @@
                   target = document.getElementById(href.split("#").pop());
               return {
                 selected: this.getAttribute("aria-selected") === "true",
-                target: target
+                target: target,
+                tab: this
               };
             }),
           panels = d3.select(this.parentNode)
@@ -424,6 +425,10 @@
         d3.event.preventDefault();
         tabs.each(function(tab) { tab.selected = false; });
         d.selected = true;
+
+        // Update the type of the objects
+        d3.select("#top_table_type").text(d3.select(d.tab).attr("data-type"));
+
         update();
 
         // track in google analytics


### PR DESCRIPTION
This removes the `10` and `20` from each top table, and restores the Pages/Domains name to the header next to the tabs at the top.

Instead of separating Pages/Domains out below the word "Top" in a different sized font, as it was **before**:

![screenshot from 2015-11-04 17-31-08](https://cloud.githubusercontent.com/assets/4592/10954213/1dfe105e-831a-11e5-88a6-0029d2241a15.png)


This PR integrates the word into the header and makes it so the tabs switch the word in-place, like in these two shots:

![screenshot from 2015-11-04 17-33-34](https://cloud.githubusercontent.com/assets/4592/10954223/319d6aec-831a-11e5-8412-936fb5ac7037.png)

![screenshot from 2015-11-04 17-29-05](https://cloud.githubusercontent.com/assets/4592/10954147/c46abd30-8319-11e5-9640-4184dc899cbb.png)

And the Top Downloads section is styled identically:

![screenshot from 2015-11-04 17-29-11](https://cloud.githubusercontent.com/assets/4592/10954146/c306bf66-8319-11e5-962a-5f5cf2a36691.png)
