### PR TITLE
Update language in "30 days" to mirror in "7 days"

### DIFF
--- a/index.html
+++ b/index.html
@@ -284,7 +284,7 @@ permalink: /
             data-block="top-pages"
             data-source="{{ site.data_url }}/top-domains-30-days.json">
             <h5><em>
-              Visits over the last month to <strong>domains</strong>, including traffic to all pages within that domain.
+              Total visits over the last month to <strong>domains</strong>, including traffic to all pages within that domain.
               <a href="{{ site.data_url }}/top-domains-30-days.csv">Download the full dataset.</a>
             </em></h5>
             <div class="data bar-chart">


### PR DESCRIPTION
Both now say "Total visits over the last X to <strong>domains</strong>, including traffic to all pages within that domain"