### PR TITLE
Make the "visits" language consistent in the other direction

### DIFF
--- a/index.html
+++ b/index.html
@@ -275,7 +275,7 @@ permalink: /
           <figure class="top-pages" id="top-pages-7-days" role="tabpanel"
             data-block="top-pages"
             data-source="{{ site.data_url }}/top-domains-7-days.json">
-            <h5><em>Total visits over the last week to <strong>domains</strong>, including traffic to all pages within that domain.</em></h5>
+            <h5><em>Visits over the last week to <strong>domains</strong>, including traffic to all pages within that domain.</em></h5>
             <div class="data bar-chart">
             </div>
           </figure>
@@ -284,7 +284,7 @@ permalink: /
             data-block="top-pages"
             data-source="{{ site.data_url }}/top-domains-30-days.json">
             <h5><em>
-              Total visits over the last month to <strong>domains</strong>, including traffic to all pages within that domain.
+              Visits over the last month to <strong>domains</strong>, including traffic to all pages within that domain.
               <a href="{{ site.data_url }}/top-domains-30-days.csv">Download the full dataset.</a>
             </em></h5>
             <div class="data bar-chart">


### PR DESCRIPTION
This builds on #148 but makes the language consistent in the other direction, by removing "Total". This has the minor benefit of making the language underneath the 30 day domain tab not line-wrap, which makes the whole section more compact and aesthetically pleasing.