### PR TITLE
new % threshold means edge now appears in the list of browsers

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -179,7 +179,7 @@
       .transform(function(d) {
         var values = listify(d.totals.browser),
             total = d3.sum(values.map(function(d) { return d.value; }));
-        return addShares(collapseOther(values, total * .015));
+        return addShares(collapseOther(values, total * .013));
       })
       .render(barChart()
         .value(function(d) { return d.share * 100; })


### PR DESCRIPTION
Previously threshold was 1.5%, Edge currently has 1.4% of the traffic. As we only expect Edge traffic to increase with time, lowering the % threshold for appearing in the list (vs. being sorted into "Other") addresses this problem. The threshold may need to be adjusted in the future as these numbers change.