### PR TITLE
Fixes incorrect location data %'s

### DIFF
--- a/index.html
+++ b/index.html
@@ -185,7 +185,8 @@ permalink: /
 
           <figure id="chart_ie"
             data-block="ie"
-            data-source="{{ site.data_url }}/ie.json">
+            data-source="{{ site.data_url }}/ie.json"
+            data-scale-to-parent="true">
             <h4>Internet Explorer</h4>
             <div class="data bar-chart">
             </div>
@@ -204,7 +205,8 @@ permalink: /
 
           <figure id="chart_windows"
             data-block="windows"
-            data-source="{{ site.data_url }}/windows.json">
+            data-source="{{ site.data_url }}/windows.json"
+            data-scale-to-parent="true">
             <h4>Windows</h4>
             <div class="data bar-chart">
             </div>

--- a/js/index.js
+++ b/js/index.js
@@ -889,7 +889,7 @@
    *
    * 1. finds the selection's `.bin` child with data matching the parentFilter
    *    function (the "parent bin")
-   * 2. determines that bin's share of the total
+   * 2. determines that bin's share of the total (if `data-scale-to-parent` is "true")
    * 3. grabs all of the child `.bin`s of the child selection and updates their
    *    share (by multiplying it by the parent's)
    * 4. updates the `.bar` width  and `.value` text for each child bin
@@ -898,10 +898,13 @@
   function nestCharts(selection, parentFilter, child) {
     var parent = selection.selectAll(".bin")
           .filter(parentFilter),
+        scale = (child.attr("data-scale-to-parent") == "true"),
         share = parent.datum().share,
         bins = child.selectAll(".bin")
+          // If the child data should be scaled to be %'s of its parent bin,
+          // then multiple each child item's % share by its parent's % share.
           .each(function(d) {
-            d.share *= share;
+            if (scale) d.share *= share;
           })
           .attr("data-share", function(d) {
             return d.share;


### PR DESCRIPTION
Location data was being rendered with incorrect data, because we were running the international per-country data through the same post-render nesting process that we run the IE and Windows bar charts through.

This wasn't correct, because the Windows chart is "scaled" based on the overall % of Windows within operating systems, and the IE chart is "scaled" based on the overall % of IE within browsers. The international country information is pulling from the same report as its parent -- the nesting is just a visual convenience, without any actual mathematical scaling ramifications.

This change adds support for a `data-scale-to-parent` element for child `<figure>` elements whose bar chart data is meant to be scaled by its parent bar. It is set to `"true"` for the IE and Windows bar charts, and omitted (essentially set to `false`) for the international visits bar chart.

This corrects the international visit information:

![image](https://cloud.githubusercontent.com/assets/4592/11349844/59e92572-91fc-11e5-831b-e12676300029.png)

While leaving the browser/IE/OS/windows information intact:

![image](https://cloud.githubusercontent.com/assets/4592/11349847/69742208-91fc-11e5-83f4-1c5413d3b54f.png)

Thanks to @JuliaWinn for putting so much work into this, which pointed me in the right direction immediately. She also reviewed this code with me while I was figuring out the issue, writing it, and submitting this pull request.

Fixes #252.