### PR TITLE
Add README instruction to install analytics reporter dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ Install them all:
 bundle install
 ```
 
+[`analytics-reporter`](https://github.com/18F/analytics-reporter) is the code that powers the analytics dashboard.
+Please clone the `analytics-reporter` next to a local copy of this github repository.
+
 ### Developing locally
 
 Run Jekyll with development settings:

--- a/README.md
+++ b/README.md
@@ -82,10 +82,6 @@ make deploy
 
 **Use the full command above.** The full command ensures that the build completes successfully, with production settings, _before_ triggering an upload to the production bucket.
 
-### Fixing links in the Top 20
-
-Links pulled directly from Google Analytics are occasionally broken (this is most common in the Top 20 section). For now, we're hard coding the fix in the `index.js` file [here](https://github.com/GSA/analytics.usa.gov/blob/master/js/index.js#L6) in the format: `"broken link" : "working link",`.
-
 ### Public domain
 
 This project is in the worldwide [public domain](LICENSE.md). As stated in [CONTRIBUTING](CONTRIBUTING.md):


### PR DESCRIPTION
Re-opening https://github.com/18F/analytics.usa.gov/pull/264 on a newly created branch.  I made the mistake of not re-naming the branch `18f-pages` to a different name, which caused https://github.com/18F/analytics.usa.gov/pull/264 to accidentally close. :cry: 