### PR TITLE
Fix link to bulk download

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -312,7 +312,7 @@
             data-source="{{ data_url }}/top-domains-30-days.json">
             <h5><em>
               Visits over the last month to <strong>domains</strong>, including traffic to all pages within that domain.
-              <a href="{{ data_url }}/top-domains-30-days.csv">Download the full dataset.</a>
+              <a href="{{ data_url }}/all-domains-30-days.csv">Download the full dataset.</a>
             </em></h5>
             <div class="data bar-chart">
             </div>


### PR DESCRIPTION
The link we conveniently put at the top to the bulk download under the 30 days tab was actually linking to the top-20 download instead of the full one. This fixes that.