### PR TITLE
Reflect every 2 minutes for real-time downloads

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -386,7 +386,7 @@
               <a href="{{ data_url }}/windows.csv" class="download-data">Versions of Windows</a>
             </li>
           </ul>
-          <h4>Updated every minute</h4>
+          <h4>Updated every two minutes</h4>
 
           <ul>
             <li>


### PR DESCRIPTION
Switching the downloadable data from "updated every minute" to "updated every two minutes" to reflect the change we made to conserve API calls