### PR TITLE
Reflecting "agency" downloads

### DIFF
--- a/_layouts/agencies.html
+++ b/_layouts/agencies.html
@@ -326,7 +326,7 @@
         <section id="top_downloads_table">
 
           <h3>Top Downloads</h3>
-          <h5><em>Total file downloads yesterday on government domains.</em></h5>
+          <h5><em>Total file downloads yesterday on agency domains.</em></h5>
           <figure id="top-downloads"
             data-block="top-downloads"
             data-source="{{ data_url }}/top-downloads-yesterday.json">


### PR DESCRIPTION
Instead of "government", a la the previous change to total number of real-time visitors