### PR TITLE
Fixed favicon for agency pages

### DIFF
--- a/_layouts/agencies.html
+++ b/_layouts/agencies.html
@@ -28,7 +28,7 @@
     <meta name="google-site-verification" content="NjbZn6hQe7OwV-nTsa6nLmtrOUcSGPRyFjxm5zkmCcg" />
 
     <link rel="stylesheet" href="{{ site.baseurl }}/css/public_analytics.css">
-    <link rel="icon" type="image/x-icon" href="images/analytics-favicon.ico">
+    <link rel="shortcut icon"  href="../images/analytics-favicon.ico" type="image/x-icon">
 
     <meta name="twitter:site" content="@{{ site.twitter }}">
     <meta name="twitter:creator" content="@{{ site.twitter }}">


### PR DESCRIPTION
Addresses #312  . Just fixes the favicon for the agency level pages.