### PR TITLE
Fix some USPS case sensitive URLs

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -13,6 +13,14 @@
     "irs.gov/forms-&-pubs": "https://www.irs.gov/Forms-&-Pubs",
     "ebenefits.va.gov/ebenefits/homepage": "https://www.ebenefits.va.gov/ebenefits/homepage",
 
+    // USPS is afflicted with a bad case of sensitivity :(
+    "m.usps.com/m/trackconfirmaction": "https://m.usps.com/m/TrackConfirmAction",
+    "tools.usps.com/go/trackconfirmaction_input": "https://tools.usps.com/go/TrackConfirmAction!input",
+    "m.usps.com/m/home": "https://m.usps.com/m/Home",
+    "reg.usps.com/entreg/loginaction_input?appurl=https://cns.usps.com/labelinformation.shtml": "https://reg.usps.com/entreg/LoginAction!input?appurl=https://cns.usps.com/labelinformation.shtml",
+    "tools.usps.com/go/ziplookupaction!input.action": "https://tools.usps.com/go/ZipLookupAction!input.action",
+    "cns.usps.com/labelinformation.shtml": "https://cns.usps.com/labelInformation.shtml",
+
     // for 7/30 days tabs
     "egov.uscis.gov": "https://egov.uscis.gov/casestatus/",
     "wrh.noaa.gov": "http://www.wrh.noaa.gov"


### PR DESCRIPTION
USPS.com has a bad case of sensitivity. This makes the 6 USPS sites showing up in the top 20 work when clicked. 