### PR TITLE
touch up navbar

### DIFF
--- a/_layouts/agencies.html
+++ b/_layouts/agencies.html
@@ -107,37 +107,26 @@
       {% capture data_url %}{{ page.data_url }}{% endcapture %}
       {% capture page_title %} - {{ page.name }}{% endcapture %}
     {% endif %}
-    <header id="usa_dot_gov_header">
-      <div class="header_container">
-	      <h1>
-          <a href="/" class="external-link anlytics-title"><b>analytics</b>.usa.gov</a>
-          {% if site.agencies.size > 0 %}
-          <div id="agency-selector-wrap">
-            &nbsp-
-            <select id="agency-selector" title="Agency Selection Dropdown" class="agency-selector">
-              <option value="{{site.baseurl}}/">{{site.dropdown_title}}</option>
-              {% for agency in site.agencies %}
-                <option value="{{site.baseurl}}{{agency.url}}">{{agency.name}}</option>
-              {% endfor %}
-            </select>
-          </div>
-          {% endif %}
-        </h1>
 
-        <a id="about" href="#explanation" class="site-nav">About this site</a>
+    <header>
+      <div class="inner clearfix">
+        <a href="#explanation" class="el right">
+          About <span class="sm-hide">this site</span>
+        </a>
+        <a href="/" class="el left brand">
+          <strong>analytics</strong>.usa.gov
+        </a>
         {% if site.agencies.size > 0 %}
-          <div id="agency-selector-wrap-small">
-            <select id="agency-selector-small" title="Agency Selection Dropdown" class="agency-selector">
-              <option value="{{site.baseurl}}/">{{site.dropdown_title}}</option>
-              {% for agency in site.agencies %}
-                <option value="{{site.baseurl}}{{agency.url}}">{{agency.name}}</option>
-              {% endfor %}
-            </select>
-          </div>
-          {% endif %}
+        <div class="el left agency-selector-wrap">
+          <select class="agency-selector" title="Agency Selection Dropdown">
+            <option value="{{site.baseurl}}/">{{site.dropdown_title}}</option>
+            {% for agency in site.agencies %}
+              <option value="{{site.baseurl}}{{agency.url}}">{{agency.name}}</option>
+            {% endfor %}
+          </select>
+        </div>
+        {% endif %}
       </div>
-
-      <div id="color_bar"></div>
     </header>
 
     <div class="container">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -108,37 +108,26 @@
       {% capture data_url %}{{ page.data_url }}{% endcapture %}
       {% capture page_title %} - {{ page.name }}{% endcapture %}
     {% endif %}
-    <header id="usa_dot_gov_header">
-      <div class="header_container">
-        <h1>
-          <a href="/" class="external-link anlytics-title"><b>analytics</b>.usa.gov</a>
-          {% if site.agencies.size > 0 %}
-          <div id="agency-selector-wrap">
-            &nbsp-
-            <select id="agency-selector" title="Agency Selection Dropdown" class="agency-selector">
-              <option value="{{site.baseurl}}/">{{site.dropdown_title}}</option>
-              {% for agency in site.agencies %}
-                <option value="{{site.baseurl}}{{agency.url}}">{{agency.name}}</option>
-              {% endfor %}
-            </select>
-          </div>
-          {% endif %}
-        </h1>
 
-        <a id="about" href="#explanation" class="site-nav">About this site</a>
+    <header>
+      <div class="inner clearfix">
+        <a href="#explanation" class="el right">
+          About <span class="sm-hide">this site</span>
+        </a>
+        <a href="/" class="el left brand">
+          <strong>analytics</strong>.usa.gov
+        </a>
         {% if site.agencies.size > 0 %}
-          <div id="agency-selector-wrap-small">
-            <select id="agency-selector-small" title="Agency Selection Dropdown" class="agency-selector">
-              <option value="{{site.baseurl}}/">{{site.dropdown_title}}</option>
-              {% for agency in site.agencies %}
-                <option value="{{site.baseurl}}{{agency.url}}">{{agency.name}}</option>
-              {% endfor %}
-            </select>
-          </div>
-          {% endif %}
+        <div class="el left agency-selector-wrap">
+          <select class="agency-selector" title="Agency Selection Dropdown">
+            <option value="{{site.baseurl}}/">{{site.dropdown_title}}</option>
+            {% for agency in site.agencies %}
+              <option value="{{site.baseurl}}{{agency.url}}">{{agency.name}}</option>
+            {% endfor %}
+          </select>
+        </div>
+        {% endif %}
       </div>
-
-      <div id="color_bar"></div>
     </header>
 
     <div class="container">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -111,14 +111,16 @@
 
     <header>
       <div class="inner clearfix">
-        <a href="#explanation" class="el right">
+        <h1>
+          <a href="/" class="external-link">
+            <strong>analytics</strong>.usa.gov
+          </a>
+        </h1>
+        <a href="#explanation" id="about" class="el">
           About <span class="sm-hide">this site</span>
         </a>
-        <a href="/" class="el left brand">
-          <strong>analytics</strong>.usa.gov
-        </a>
         {% if site.agencies.size > 0 %}
-        <div class="el left agency-selector-wrap">
+        <div class="el agency-selector-wrap">
           <select class="agency-selector" title="Agency Selection Dropdown">
             <option value="{{site.baseurl}}/">{{site.dropdown_title}}</option>
             {% for agency in site.agencies %}

--- a/css/public_analytics.scss
+++ b/css/public_analytics.scss
@@ -78,105 +78,9 @@ body {
   }
 }
 
-a, a:visited {
+a,
+a:visited {
   color: $dark_blue;
-}
-
-.anlytics-title {
-  float:left;
-}
-
-.agency-selector {
-  background: url(../images/white-arrow-down.png) 98% no-repeat white ;
-  background-size: 7%;
-  background-color: #36435A;
-  color: white;
-  font-size: .8em;
-  font-weight: 600;
-  padding: 2px 2px 2px 10px;
-  width:95%;
-  border: 1px solid white;
-  border-radius: 5px;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  left:50px;
-  @include media($small-screen) {
-    padding: 2px 2px 2px 5px;
-  }
-}
-
-#agency-selector-wrap {
-  float:right;
-  width:100%;
-  float:left; 
-  display:inline;
-  @include media($xxlarge-screen) {
-    width: 60%;
-  }
-  @include media($xlarge-screen) {
-    width: 70%;
-  }
-  @include media($large-screen)  {
-    width: 60%;
-    display:none;
-  }
-  @include media($medium-screen) {
-    width:  50%;
-    display:none;
-  }
-  @include media($small-screen)  {
-    width:  40%;
-    display:none;
-  }
-}
-
-#agency-selector-wrap-small {
-  float:right;
-  width:100%;
-  float:left;
-  font-size:1.4em;
-  display:inline;
-  max-width:400px;
-  @include media($xxlarge-screen) {
-    display:none;
-  }
-  @include media($xlarge-screen) {
-    width: 60%;
-    display:none;
-  }
-  @include media($large-screen)  {
-    width: 50%;
-    display:inline;
-    max-width:  550px;
-    padding-bottom:10px;
-  }
-  @include media($medium-screen) {
-    width:  60%;
-    display:inline;
-    max-width:450px;
-    padding-bottom:10px;
-  }
-  @include media($small-screen)  {
-    width:  85%;
-    display:inline;
-    max-width:450px;
-    padding-bottom:10px;
-  }
-  @include media($mobile-small-screen) {
-    width:  100%;
-    display:inline;
-    max-width:450px;
-    padding-bottom:10px;
-    font-size: larger;
-  }
-}
-
-
-#usa_dot_gov_header {
-  a, a:visited {
-    color: $white;
-  }
 }
 
 h2 {
@@ -199,53 +103,105 @@ h5 {
   font-weight: 400;
 }
 
+
+/*
+* utility classes for layout & display
+*/
+
+@include media($small-screen) {
+  .sm-hide { display: none !important }
+}
+
+.clearfix:before,
+.clearfix:after {
+  content: " ";
+  display: table
+}
+.clearfix:after { clear: both }
+
+.left  { float: left }
+.right { float: right }
+
+/*
+* end utility classes
+*/
+
+
+/*
+* top navigation bar
+*/
+
 header {
   background: $dark_blue;
-  color: white;
+  color: $white;
+  border-bottom: 6px solid $light_blue;
 
-  .header_container {
-    @include responsive_container;
-    padding: 0 1em;
+  .inner { padding: 0 1em; }
+
+  .brand {
+    margin-right: 24px;
+    font-size: 36px;
   }
 
-  #color_bar {
-    background: $light_blue;
-    height: 6px;
+  .el {
+    padding: 20px 0;
+    line-height: 60px;
   }
 
-  h1 {
-    @include span-columns(12);
-    font-weight: $bold_weight;
-    a {
-      font-weight: 300;
-      color: white;
-      text-decoration: none;
-    }
-    a:hover {
-      text-decoration: underline;
-    }
-    @include media($small-screen)  {
-      @include span-columns(1);
-    }
+  .agency-selector-wrap {
+    width: 50%;
   }
 
-  #about {
-    font-size: 1em;
+  .agency-selector {
+    width: 100%;
+    height: 40px;
+    color: $white;
+    background-color: transparent;
+    font-size: 22px;
+    font-weight: 600;
+    vertical-align: middle;
+    border: 1px solid $white;
+    border-radius: $border_radius;
+  }
+
+  a {
+    color: $white;
     font-weight: 300;
-    @include span-columns(2);
-    padding-top: 2em;
-    text-align: right;
     text-decoration: none;
-    border: none;
-    @include media($small-screen)  {
-      @include span-columns(1);
-      text-align: left;
+  }
+  a:hover {
+    text-decoration: underline;
+  }
+  a:visited {
+    color: $white;
+  }
+
+  @include media($medium-screen) {
+    .brand {
+      font-size: 26px;
+      float: none;
+      display: block;
+    }
+
+    .el {
+      line-height: 30px;
+    }
+
+    .agency-selector-wrap {
       padding-top: 0;
-      padding-bottom: 10px;
+      width: 100%;
+    }
+
+    .agency-selector {
+      font-size: 16px;
     }
   }
-  #about:hover {text-decoration: underline;}
 }
+
+/*
+* end top navigation bar
+*/
+
 
 section {
   background: $white;

--- a/css/public_analytics.scss
+++ b/css/public_analytics.scss
@@ -109,18 +109,16 @@ h5 {
 */
 
 @include media($small-screen) {
-  .sm-hide { display: none !important }
+  .sm-hide { display: none !important; }
 }
 
 .clearfix:before,
 .clearfix:after {
   content: " ";
-  display: table
+  display: table;
 }
-.clearfix:after { clear: both }
+.clearfix:after { clear: both; }
 
-.left  { float: left }
-.right { float: right }
 
 /*
 * end utility classes
@@ -132,36 +130,28 @@ h5 {
 */
 
 header {
+  @include responsive_container;
   background: $dark_blue;
   color: $white;
   border-bottom: 6px solid $light_blue;
 
   .inner { padding: 0 1em; }
 
-  .brand {
+  h1 {
+    float: left;
     margin-right: 24px;
     font-size: 36px;
+    @include media($medium-screen) {
+      line-height: 30px;
+    }
   }
 
   .el {
     padding: 20px 0;
     line-height: 60px;
-  }
-
-  .agency-selector-wrap {
-    width: 50%;
-  }
-
-  .agency-selector {
-    width: 100%;
-    height: 40px;
-    color: $white;
-    background-color: transparent;
-    font-size: 22px;
-    font-weight: 600;
-    vertical-align: middle;
-    border: 1px solid $white;
-    border-radius: $border_radius;
+    @include media($medium-screen) {
+      line-height: 30px;
+    }
   }
 
   a {
@@ -175,26 +165,37 @@ header {
   a:visited {
     color: $white;
   }
+}
+
+#about {
+  float: right;
+}
+
+.agency-selector-wrap {
+  width: 50%;
+  float: left;
+  @include media($medium-screen) {
+    width:  80%;
+  }
+  @include media($small-screen)  {
+    width:  100%;
+    float: none;
+  }
+}
+
+.agency-selector {
+  width: 100%;
+  height: 40px;
+  color: $white;
+  background-color: transparent;
+  font-size: 22px;
+  font-weight: 600;
+  vertical-align: middle;
+  border: 1px solid $white;
+  border-radius: $border_radius;
 
   @include media($medium-screen) {
-    .brand {
-      font-size: 26px;
-      float: none;
-      display: block;
-    }
-
-    .el {
-      line-height: 30px;
-    }
-
-    .agency-selector-wrap {
-      padding-top: 0;
-      width: 100%;
-    }
-
-    .agency-selector {
-      font-size: 16px;
-    }
+    font-size: 16px;
   }
 }
 


### PR DESCRIPTION
This PR addresses https://github.com/18F/analytics.usa.gov/issues/334 and https://github.com/18F/analytics.usa.gov/issues/335.

It simplifies the HTML and Sass for the top navigation (i.e., now only one dropdown vs. the two before that toggled visibility based on screen size) and conserves vertical space on small screens (2 rows instead of 3).

The various states look like this:

**large screen**:

![image](https://cloud.githubusercontent.com/assets/1060893/14126457/274d2162-f5df-11e5-994e-b876593c97ae.png)

**medium screen**:

![image](https://cloud.githubusercontent.com/assets/1060893/14126477/3f61c15e-f5df-11e5-9c52-965fa4c14563.png)

**small screen**:

![image](https://cloud.githubusercontent.com/assets/1060893/14126483/4c863306-f5df-11e5-8ceb-b847a932601a.png)

(Note that "About this site" degrades to "About" for small screens for space savings)




