### PR TITLE
Updated readme for local dev data location

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ To compile the Sass stylesheets once, run `make clean all`, or `make -B` to comp
 
 ### Developing with local data
 
-The development settings assume data is available at `http://localhost:4000`.
+The development settings assume data is available at `/fakedata`. You can change this in `_development.yml`.
+
 
 ### Developing with real live data from `analytics-reporter`
 


### PR DESCRIPTION
`http://localhost:4000` is the address of the dashboard when following the Readme. 
I think the original `_development.yml` settings pull data from `/fakedata` ?