### PR TITLE
Change Sass variables to be descriptive

### DIFF
--- a/css/public_analytics.scss
+++ b/css/public_analytics.scss
@@ -11,7 +11,7 @@ $gutter: 0em !global;
 @import "neat/neat";
 
 
-@mixin responsive_container {
+@mixin responsive-container {
   @include outer-container;
 
   @include media($xlarge-screen) {
@@ -28,6 +28,7 @@ $gutter: 0em !global;
   }
 }
 
+// Breakpoints
 $xxlarge-screen: new-breakpoint(max-width  4000px  14);
 $xlarge-screen: new-breakpoint(max-width  1600px  14);
 $large-screen:  new-breakpoint(max-width  1200px  14);
@@ -35,40 +36,34 @@ $medium-screen: new-breakpoint(max-width  992px   14);
 $small-screen:  new-breakpoint(max-width  768px   1);
 $mobile-small-screen:  new-breakpoint(max-width  500px   1);
 
-// Fonts & Colors:
-
-$red: #921B1E;
-$blue: #022945;
-
-$light_gray: #f9f9f9;
-$dark_gray: #222;
-$medium_gray: #555;
-
-// used only for borders
-$gray: #e4e4e4;
-
-// Formerly #3A96B7 -> See issue #319 
-$light_blue: #237fa0;
-$dark_blue: #36435A;
+// Colors
+$light-gray: #f9f9f9;
 $white: #fff;
-$background_color: $light_gray;
-$container_background: $white;
-$border_width: 1px;
 
-$bold_weight: 600;
+// Branding
+$background-color: $light-gray;
 
-$data: $light_blue;
+$branding-primary: #36435A;
+$branding-secondary: #237fa0;
 
-// Other Setup:
-$border_radius: 5px;
+$chart-color-data: $branding-secondary;
+$chart-color-background: $light-gray;
+
+// UI Settings
+$bold-weight: 600;
+$border-color: #e4e4e4;
+$border-radius: 5px;
+$border-width: 1px;
+$font-color: #222;
+$font-color-muted: #555;
+$section-border: $border-width solid $border-color;
 
 body {
   font-family: "Open Sans", Helvetica, arial, sans-serif;
   font-size: 18px;
-  $em-size: 18px;
   font-weight: 300;
-  color: $dark_gray;
-  background: $background_color;
+  color: $font-color;
+  background: $background-color;
   margin: 0;
   @include media($medium-screen) {
     font-size: 14px;
@@ -80,7 +75,7 @@ body {
 
 a,
 a:visited {
-  color: $dark_blue;
+  color: $branding-primary;
 }
 
 
@@ -138,10 +133,10 @@ h5 {
 */
 
 header {
-  @include responsive_container;
-  background: $dark_blue;
+  @include responsive-container;
+  background: $branding-primary;
   color: $white;
-  border-bottom: 6px solid $light_blue;
+  border-bottom: 6px solid $branding-secondary;
 
   .inner { padding: 0 1em; }
 
@@ -196,12 +191,12 @@ header {
   width: 100%;
   height: 40px;
   color: $white;
-  background-color: $dark_blue;
+  background-color: $branding_primary;
   font-size: 22px;
   font-weight: 600;
   vertical-align: middle;
   border: 1px solid $white;
-  border-radius: $border_radius;
+  border-radius: $border-radius;
 
   @include media($medium-screen) {
     font-size: 16px;
@@ -229,17 +224,17 @@ section {
 }
 
 #realtime {
-  color: $dark_blue;
+  color: $branding-primary;
   @include media($small-screen)  {
     font-size: 12px;
   }
 }
 
 .container {
-  @include responsive_container;
-  border-left: 1px solid $gray;
-  border-right: 1px solid $gray;
-  border-bottom: 1px solid $gray;
+  @include responsive-container;
+  border-left: $section-border;
+  border-right: $section-border;
+  border-bottom: $section-border;
   background: $white;
 }
 
@@ -263,17 +258,17 @@ section {
     text-align: right;
     margin-top: -2.5rem;
     font-size: 1.0em;
-    color: $dark_gray;
+    color: $font-color;
   }
 }
 
 #secondary_data {
-  border-left: 1px solid $gray;
+  border-left: $section-border;
 
   @include span-columns(5);
   @include media($small-screen)  {
     @include span-columns(1);
-    border-top: 1px solid $gray;
+    border-top: $section-border;
     border-left: none;
     border-right: none;
   }
@@ -288,7 +283,7 @@ section {
 
 #explanation,
 #data_download {
-  border-top: $border_width solid $gray;
+  border-top: $section-border;
   line-height: 1.6;
 
   h4 {font-size: 90%}
@@ -327,7 +322,7 @@ section {
 
 .section_headline {
   padding: 0.1em 1em;
-  border-top: 1px solid $gray;
+  border-top: $section-border;
   @include media($small-screen)  {
     border-bottom: none;
   }
@@ -335,11 +330,11 @@ section {
 
 .section_subheadline {
   padding: 0.5em 1em;
-  border-top: 1px solid $gray;
+  border-top: $section-border;
   text-align: center;
   font-size: 1.5em;
   #total_visitors {
-    font-weight: $bold_weight;
+    font-weight: $bold-weight;
   }
 }
 
@@ -349,7 +344,7 @@ section {
   @include media($small-screen)  {
     @include span-columns(1);
     border-left: none;
-    border-top: 1px solid $gray;
+    border-top: $section-border;
   }
   h4 {
     text-align: center;
@@ -379,7 +374,7 @@ section {
   left: 0;
   right: 0;
   height: 100%;
-  background: $dark_blue;
+  background: $branding-primary;
   color: white;
   vertical-align: middle;
   padding: 10em;
@@ -424,7 +419,7 @@ section {
 }
 
 #current_visitors {
-  font-weight: $bold_weight;
+  font-weight: $bold-weight;
   text-align: center;
 }
 
@@ -445,7 +440,7 @@ section {
     font-size: 1.0em;
   }
   h5 {
-    color: $dark_gray;
+    color: $font-color;
     font-weight: 300;
   }
 }
@@ -465,8 +460,8 @@ ul.pills {
   @include span-columns(3 of 5);
   display: inline-block;
 
-  border-right: 1px solid $gray;
-  border-left: 1px solid $gray;
+  border-right: 1px solid $border-color;
+  border-left: 1px solid $border-color;
 
   li {
     width: 33.3333%;
@@ -487,7 +482,7 @@ ul.pills {
     float: left;
 
     & > a {
-      color: $dark_blue;
+      color: $branding-primary;
       background: $white;
       width: 100%;
       text-align: center;
@@ -497,9 +492,9 @@ ul.pills {
       padding: .32em 0em;
       text-decoration: none;
 
-      border-top: 1px solid $gray;
-      border-bottom: 1px solid $gray;
-      border-right: 1px solid $gray;
+      border-top: 1px solid $border-color;
+      border-bottom: 1px solid $border-color;
+      border-right: 1px solid $border-color;
 
       &:hover {
         text-decoration: underline;
@@ -507,7 +502,7 @@ ul.pills {
 
       &[aria-selected='true'] {
         color: #fff;
-        background: $light_blue;
+        background: $branding-secondary;
       }
     }
 
@@ -545,7 +540,7 @@ ul.pills {
       content: " ";
       display: block;
       position: absolute;
-      background: #f9f9f9;
+      background: $chart-color-background;
       top: 0;
       left: 100%;
       width: 1000px;
@@ -556,7 +551,7 @@ ul.pills {
 
   .bar {
     height: .5rem;
-    background: $data;
+    background: $chart-color-data;
     position: relative;
     z-index: 2;
     min-width: 1px;
@@ -601,7 +596,7 @@ ul.pills {
   }
 
   .domain {
-    color: $medium_gray;
+    color: $font-color-muted;
   }
 }
 
@@ -613,20 +608,20 @@ g.axis {
   }
 
   .tick text {
-    fill: $dark_gray;
+    fill: $font-color;
     font-size: .75rem;
   }
 }
 
 .time-series {
   rect {
-    fill: $data;
+    fill: $chart-color-data;
     stroke: #fff;
     stroke-width: 1;
   }
 
   text.label {
-    fill: $dark_gray;
+    fill: $font-color;
     font-size: .6rem;
   }
 }


### PR DESCRIPTION
I've quickly looked to see if 18F had a style guide for Sass but I didn't find anything. I've renamed the Sass variables to be more descriptive, which would allow easier branding for forks, and to go by the opinionated [Sass Guidelines](https://sass-guidelin.es/#naming-conventions) which uses hyphens instead of underscores.

Hope no one minds!