### PR TITLE
Add vets.gov to list of VA websites

### DIFF
--- a/data/sites.csv
+++ b/data/sites.csv
@@ -4079,6 +4079,7 @@ vepo.gsfc.nasa.gov,National Aeronautics and Space Administration
 vetbiz.gov,Department of Veterans Affairs
 vetcenter.va.gov,Department of Veterans Affairs
 veterantraining.va.gov,Department of Veterans Affairs
+vets.gov,Department of Veterans Affairs
 vi.water.usgs.gov,Department of Interior
 video.nrc.gov,Nuclear Regulatory Commission
 video.state.gov,Department of State


### PR DESCRIPTION
Please include this new vets.gov website into your metrics for Dept. of Veterans Affairs. (specifically https://analytics.usa.gov/veterans-affairs/)

If there is anything else I need to do, or any other info you need, in order to make this happen, please let me know.

John.