### PR TITLE
Updated makefile to properly set mimetype for new CSS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,5 +7,14 @@ dev:
 	bundle exec jekyll serve --watch --config=_config.yml,_development.yml
 
 deploy:
-	make production && s3cmd put --recursive -P -M --add-header="Cache-Control:max-age=0" _site/* s3://$(DEPLOY_BUCKET)/ && s3cmd put -P --mime-type="text/css" --add-header="Cache-Control:max-age=0" _site/css/*.css s3://$(DEPLOY_BUCKET)/css/
+	make production && \
+	s3cmd put --recursive -P -M \
+	--add-header="Cache-Control:max-age=0" _site/* \
+	s3://$(DEPLOY_BUCKET)/ && \
+	s3cmd put -P --mime-type="text/css" \
+	--add-header="Cache-Control:max-age=0" _site/css/*.css \
+	s3://$(DEPLOY_BUCKET)/css/ && \
+	s3cmd put -P --mime-type="text/css" \
+	--add-header="Cache-Control:max-age=0" _site/css/vendor/*.css \
+	s3://$(DEPLOY_BUCKET)/css/vendor/
 


### PR DESCRIPTION
This fixes a deployment issue that was occurring where the new vendor'd uswd.css wasn't having its mime type set properly by `s3cmd`.