### PR TITLE
correct command to start jekkyl if someone does not use make

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Run Jekyll with development settings:
 make dev
 ```
 
-(This runs `bundle exec jekyll serve --watch --config _.yml,_development.yml`.)
+(This runs `bundle exec jekyll serve --watch --config=_config.yml,_development.yml`.)
 
 Sass can watch the .scss source files for changes, and build the .css files automatically:
 


### PR DESCRIPTION
After `make dev` command we can see that command that is run is different than command in README.md. 