### PR TITLE
Updates data page to reference 3 minutes instead of 2

### DIFF
--- a/_includes/data_download.html
+++ b/_includes/data_download.html
@@ -62,12 +62,12 @@
             <tr>
               <td>All pages people are visiting</td>
               <td><a href="{{ data_url }}/all-pages-realtime.csv" class="download-data"><span class="usa-label-big">CSV</span></a></td>
-              <td>Every 2 minutes</td>
+              <td>Every 3 minutes</td>
             </tr>
             <tr>
               <td>Total people online</td>
               <td><a href="{{ data_url }}/realtime.json" class="download-data"><span class="usa-label-big">JSON</span></a></td>
-              <td>Every 2 minutes</td>
+              <td>Every 3 minutes</td>
             </tr>
           </tbody>
         </table>
@@ -92,12 +92,12 @@
             <tr>
               <td>Visitors per country</td>
               <td><a href="{{ data_url }}/top-countries-realtime.json" class="download-data"><span class="usa-label-big">JSON</span></a></td>
-              <td>Every 2 minutes</td>
+              <td>Every 3 minutes</td>
             </tr>
             <tr>
               <td>Visitors per city</td>
               <td><a href="{{ data_url }}/top-cities-realtime.json" class="download-data"><span class="usa-label-big">JSON</span></a></td>
-              <td>Every 2 minutes</td>
+              <td>Every 3 minutes</td>
             </tr>
 
             <tr>


### PR DESCRIPTION
We bumped it up from 2 to 3 to support the new agency pages and remain under API quotas.