### PR TITLE
Adds new browser/version combination data to data page

### DIFF
--- a/_includes/charts.html
+++ b/_includes/charts.html
@@ -59,6 +59,10 @@
             <div class="data bar-chart">
             </div>
           </figure>
+
+          <p>
+            Much more detailed data is available in <a href="data/">downloadable CSV and JSON</a>. This includes data on combined browser and OS usage.
+          </p>
         </section>
 
         <section id="browsers" class="three_column">

--- a/_includes/data_download.html
+++ b/_includes/data_download.html
@@ -107,22 +107,58 @@
               </tr>
               <tr class="parent">
                 <td>Web browsers</td>
-                <td><a href="{{ data_url }}/browsers.csv" class="download-data"><span class="usa-label-big">CSV</span></a></td>
+                <td>
+                  <a href="{{ data_url }}/browsers.csv" class="download-data"><span class="usa-label-big">CSV</span></a>
+                  <a href="{{ data_url }}/browsers.json" class="download-data"><span class="usa-label-big">JSON</span></a>
+                </td>
                 <td>Daily</td>
               </tr>
               <tr class="subset">
                 <td>Versions of Internet Explorer</td>
-                <td><a href="{{ data_url }}/ie.csv" class="download-data"><span class="usa-label-big">CSV</span></a></td>
+                <td>
+                  <a href="{{ data_url }}/ie.csv" class="download-data"><span class="usa-label-big">CSV</span></a>
+                  <a href="{{ data_url }}/ie.json" class="download-data"><span class="usa-label-big">JSON</span></a>
+                </td>
                 <td>Daily</td>
               </tr>
               <tr class="parent">
                 <td>Operating systems</td>
-                <td><a href="{{ data_url }}/os.csv" class="download-data"><span class="usa-label-big">CSV</span></a></td>
+                <td>
+                  <a href="{{ data_url }}/os.csv" class="download-data"><span class="usa-label-big">CSV</span></a>
+                  <a href="{{ data_url }}/os.json" class="download-data"><span class="usa-label-big">JSON</span></a>
+                </td>
                 <td>Daily</td>
               </tr>
               <tr class="subset">
                 <td>Versions of Windows</td>
-                <td><a href="{{ data_url }}/windows.csv" class="download-data"><span class="usa-label-big">CSV</span></a></td>
+                <td>
+                  <a href="{{ data_url }}/windows.csv" class="download-data"><span class="usa-label-big">CSV</span></a>
+                  <a href="{{ data_url }}/windows.json" class="download-data"><span class="usa-label-big">JSON</span></a>
+                </td>
+                <td>Daily</td>
+              </tr>
+              <tr>
+                <td>OS &amp; browser (combined)</td>
+                <td>
+                  <a href="{{ data_url }}/os-browsers.csv" class="download-data"><span class="usa-label-big">CSV</span></a>
+                  <a href="{{ data_url }}/os-browsers.json" class="download-data"><span class="usa-label-big">JSON</span></a>
+                </td>
+                <td>Daily</td>
+              </tr>
+              <tr>
+                <td>Windows &amp; browser (combined)</td>
+                <td>
+                  <a href="{{ data_url }}/windows-browsers.csv" class="download-data"><span class="usa-label-big">CSV</span></a>
+                  <a href="{{ data_url }}/windows-browsers.json" class="download-data"><span class="usa-label-big">JSON</span></a>
+                </td>
+                <td>Daily</td>
+              </tr>
+              <tr>
+                <td>Windows &amp; IE (combined)</td>
+                <td>
+                  <a href="{{ data_url }}/windows-ie.csv" class="download-data"><span class="usa-label-big">CSV</span></a>
+                  <a href="{{ data_url }}/windows-ie.json" class="download-data"><span class="usa-label-big">JSON</span></a>
+                </td>
                 <td>Daily</td>
               </tr>
               <tr>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -7,7 +7,7 @@
           </p>
 
           <p>
-            Not every government website is represented in this data. Currently, the Digital Analytics Program collects web traffic from around <a href="https://analytics.usa.gov/data/live/second-level-domains.csv" class="external-link">400 executive branch government domains</a>, across <a href="https://analytics.usa.gov/data/sites.csv" class="external-link">over 4000 total websites</a>, including every cabinet department. We continue to pursue and add more sites frequently; to add your site, <a href="mailto:DAP@support.digitalgov.gov" class="external-link">email the Digital Analytics Program</a>.
+            Not every government website is represented in this data. Currently, the Digital Analytics Program collects web traffic from around <a href="https://analytics.usa.gov/data/live/second-level-domains.csv" class="external-link">400 executive branch government domains</a>, across <a href="https://analytics.usa.gov/data/sites.csv" class="external-link">about 5000 total websites</a>, including every cabinet department. We continue to pursue and add more sites frequently; to add your site, <a href="mailto:DAP@support.digitalgov.gov" class="external-link">email the Digital Analytics Program</a>.
           </p>
 
 

--- a/css/public_analytics.scss
+++ b/css/public_analytics.scss
@@ -404,6 +404,10 @@ section {
   }
 }
 
+#devices p {
+  font-size: 1.3rem;
+}
+
 .downloads {
   @include media($mobile-small-screen){
     thead th {

--- a/js/index.js
+++ b/js/index.js
@@ -148,7 +148,9 @@
     // the windows block is a stack layout
     "windows": renderBlock()
       .transform(function(d) {
-        return addShares(listify(d.totals.os_version));
+        var values = listify(d.totals.os_version),
+            total = d3.sum(values.map(function(d) { return d.value; }));
+        return addShares(collapseOther(values, total * .01)); // % of Windows
       })
       .render(barChart()
         .value(function(d) { return d.share * 100; })
@@ -179,7 +181,7 @@
       .transform(function(d) {
         var values = listify(d.totals.browser),
             total = d3.sum(values.map(function(d) { return d.value; }));
-        return addShares(collapseOther(values, total * .013));
+        return addShares(collapseOther(values, total * .01));
       })
       .render(barChart()
         .value(function(d) { return d.share * 100; })
@@ -189,7 +191,9 @@
     // data beforehand to match the expected object format
     "ie": renderBlock()
       .transform(function(d) {
-        return addShares(listify(d.totals.ie_version));
+        var values = listify(d.totals.ie_version),
+            total = d3.sum(values.map(function(d) { return d.value; }));
+        return addShares(collapseOther(values, total * .0001)); // % of IE
       })
       .render(
         barChart()


### PR DESCRIPTION
**Note:** This depends on https://github.com/18F/analytics-reporter/pull/164 being merged and deployed to production.

This links to the new bulk data reports in https://github.com/18F/analytics-reporter/pull/164 on the `/data` page. Every agency will also get their own scoped version of these reports.

I also re-added the (already generated) JSON report links next to the base `browser`, `os`, `windows`, and `ie` reports, since we do helpful aggregation in those reports (and they've been improved in 18f/analytics-reporter#164).

This looks like:

![image](https://cloud.githubusercontent.com/assets/4592/16142909/6a1cb3f4-3437-11e6-9a6d-27019caba28a.png)

The labels aren't as clear and elegant as the rest, but I'm hoping this is fine for the interim.

I also went and added thresholds to the Windows and IE versions of the chart, since 18f/analytics-reporter#164 stopped doing bucketing into an `Other` category. They remain identical to what's currently in production. I also adjusted the existing OS/browser thresholds very slightly to make sure that significant browsers (Android and iOS in-app views) both appear. 

That all now looks like this:

![image](https://cloud.githubusercontent.com/assets/4592/16142956/a5c40556-3437-11e6-8c08-cf96e976dc82.png)