### PR TITLE
Updates link to point to auto-generated sites.csv

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -7,7 +7,7 @@
           </p>
 
           <p>
-            Not every government website is represented in this data. Currently, the Digital Analytics Program collects web traffic from around <a href="https://analytics.usa.gov/data/live/second-level-domains.csv" class="external-link">400 executive branch government domains</a>, across <a href="https://analytics.usa.gov/data/sites.csv" class="external-link">over 4000 total websites</a>, including every cabinet department. We continue to pursue and add more sites frequently; to add your site, <a href="mailto:DAP@support.digitalgov.gov" class="external-link">email the Digital Analytics Program</a>.
+            Not every government website is represented in this data. Currently, the Digital Analytics Program collects web traffic from around <a href="https://analytics.usa.gov/data/live/second-level-domains.csv" class="external-link">400 executive branch government domains</a>, across <a href="https://analytics.usa.gov/data/live/sites.csv" class="external-link">over 4000 total websites</a>, including every cabinet department. We continue to pursue and add more sites frequently; to add your site, <a href="mailto:DAP@support.digitalgov.gov" class="external-link">email the Digital Analytics Program</a>.
           </p>
 
 

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -7,7 +7,7 @@
           </p>
 
           <p>
-            Not every government website is represented in this data. Currently, the Digital Analytics Program collects web traffic from around <a href="https://analytics.usa.gov/data/live/second-level-domains.csv" class="external-link">400 executive branch government domains</a>, across <a href="https://analytics.usa.gov/data/live/sites.csv" class="external-link">over 4000 total websites</a>, including every cabinet department. We continue to pursue and add more sites frequently; to add your site, <a href="mailto:DAP@support.digitalgov.gov" class="external-link">email the Digital Analytics Program</a>.
+            Not every government website is represented in this data. Currently, the Digital Analytics Program collects web traffic from around <a href="https://analytics.usa.gov/data/live/second-level-domains.csv" class="external-link">400 executive branch government domains</a>, across <a href="https://analytics.usa.gov/data/live/sites.csv" class="external-link">over 6000 total websites</a>, including every cabinet department. We continue to pursue and add more sites frequently; to add your site, <a href="mailto:DAP@support.digitalgov.gov" class="external-link">email the Digital Analytics Program</a>.
           </p>
 
 


### PR DESCRIPTION
Note: This depends on 18F/analytics-reporter#165 being merged and deployed to production.

This adjusts the link in the footer to point to the new location `sites.csv` will appear once auto-generated, and adjusts the link text to say "over 6,000 websites" instead of the current 4,000, which is in line with the current setting in https://github.com/18F/analytics-reporter/pull/165. 

If we make threshold changes in https://github.com/18F/analytics-reporter/pull/165 before merging, then the link text here will need a tweak again before merging.

Because I like including screenshots:

![image](https://cloud.githubusercontent.com/assets/4592/16143036/2dcfe5f0-3438-11e6-9f0d-376d59424ab5.png)
