### PR TITLE
Add note about traffic from government networks

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Other government agencies who have reused this project for their analytics dashb
 * http://analytics.muni.org/
 * http://analytics.smgov.net/
 
-[This blog post details their implementations and lessons learned](https://18f.gsa.gov/2016/01/05/tips-for-adapting-analytics-usa-gov/).  
+[This blog post details their implementations and lessons learned](https://18f.gsa.gov/2016/01/05/tips-for-adapting-analytics-usa-gov/).
 
 
 ### Setup
@@ -35,7 +35,7 @@ Please clone the `analytics-reporter` next to a local copy of this github reposi
   ```bash
   touch _agencies/agencyx.html
   ```
-0. Create a new html file in the `_data_pages` directory. Use the same name you used in step 2. This will be the data download page for this agency 
+0. Create a new html file in the `_data_pages` directory. Use the same name you used in step 2. This will be the data download page for this agency
 
   ```bash
   touch _data_pages/agencyx.html
@@ -65,14 +65,6 @@ make dev
 ```
 
 (This runs `bundle exec jekyll serve --watch --config=_config.yml,_development.yml`.)
-
-Sass can watch the .scss source files for changes, and build the .css files automatically:
-
-```bash
-make watch
-```
-
-To compile the Sass stylesheets once, run `make clean all`, or `make -B` to compile even if the .css file already exists.
 
 ### Developing with local data
 

--- a/_includes/charts.html
+++ b/_includes/charts.html
@@ -61,7 +61,11 @@
           </figure>
 
           <p>
-            Much more detailed data is available in <a href="data/">downloadable CSV and JSON</a>. This includes data on combined browser and OS usage.
+            Based on rough network segmentation data, we estimate that <strong>less than 5%</strong> of all traffic across all agencies comes from US federal government networks.
+          </p>
+
+          <p>
+            Much more detailed data is available in <strong><a href="data/">downloadable CSV and JSON</a></strong>. This includes data on combined browser and OS usage.
           </p>
         </section>
 


### PR DESCRIPTION
It's a rough estimate, given how imperfect the data is, but given that a lot of people drastically overestimate how much traffic is from government networks, it seems worth adding a message.

Here's a screenshot:

<img width="756" alt="screen_shot_2016-08-02_at_12 15 12_pm" src="https://cloud.githubusercontent.com/assets/4592/17389078/ec52bc62-59ce-11e6-83b6-3401dfde7980.png">

This message will appear on agency-filtered pages too, but the message is explicit about "all agencies". Still, if there are agencies for which this is drastically different, we may want to consider some agency-specific messages.