### PR TITLE
Fix link to bulk download to all top domains

### DIFF
--- a/_includes/charts.html
+++ b/_includes/charts.html
@@ -188,7 +188,7 @@
             data-source="{{ site.data_url }}/{{ data_prefix }}/top-domains-30-days.json">
             <h5><em>
               Visits over the last month to <strong>domains</strong>, including traffic to all pages within that domain. {% if entity == "government" %}We only count pages with at least 1,000 visits in the last month.{% endif %}
-              <a href="{{ site.data_url }}/{{ data_prefix }}/top-domains-30-days.csv">Download the full dataset.</a>
+              <a href="{{ site.data_url }}/{{ data_prefix }}/all-domains-30-days.csv">Download the full dataset.</a>
             </em></h5>
             <div class="data bar-chart">
             </div>


### PR DESCRIPTION
The bulk CSV download link at the top of the Top 20 Domains over 30 Days tab was linking to just the top 20, instead of to all of them as intended.