### PR TITLE
Remove data urls in favor of determining everything from slugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ bundle install
 Please clone the `analytics-reporter` next to a local copy of this github repository.
 
 ### Adding Additional Agencies
+
 0. Ensure that data is being collected for a specific agency's Google Analytics ID. Visit [18F's analytics-reporter](https://github.com/18F/analytics-reporter) for more information. Save the url path for the data collection path.
 0. Create a new html file in the `_agencies` directory. The name of the file will be the url path.
-
   ```bash
   touch _agencies/agencyx.html
   ```
@@ -59,7 +59,6 @@ Please clone the `analytics-reporter` next to a local copy of this github reposi
   ```yaml
   ---
   name: Agency X # Name of the page
-  data_url: https://analytics.usa.gov/data/agencyx # Data URL from step 1
   slug: agencyx # Same as the name of the html files. Used to generate data page links.
   layout: default # type of layout used. available layouts are in `_layouts`
   ---

--- a/_agencies/agency-international-development.html
+++ b/_agencies/agency-international-development.html
@@ -1,7 +1,6 @@
 ---
 name: Agency for International Development
 slug: agency-international-development
-data: usaid
 layout: default
 ---
       {% include charts.html %}

--- a/_agencies/education.html
+++ b/_agencies/education.html
@@ -1,7 +1,6 @@
 ---
 name: Department of Education
 slug: education
-data: ed
 layout: default
 ---
       {% include charts.html %}

--- a/_agencies/environmental-protection-agency.html
+++ b/_agencies/environmental-protection-agency.html
@@ -1,7 +1,6 @@
 ---
 name: Environmental Protection Agency
 slug: environmental-protection-agency
-data: epa
 layout: default
 ---
       {% include charts.html %}

--- a/_agencies/executive-office-president.html
+++ b/_agencies/executive-office-president.html
@@ -1,7 +1,6 @@
 ---
 name: Executive Office of the President
 slug: executive-office-president
-data: eop
 layout: default
 ---
       {% include charts.html %}

--- a/_agencies/general-services-administration.html
+++ b/_agencies/general-services-administration.html
@@ -1,7 +1,6 @@
 ---
 name: General Services Administration
 slug: general-services-administration
-data: gsa
 layout: default
 ---
      {% include charts.html %}

--- a/_agencies/health-human-services.html
+++ b/_agencies/health-human-services.html
@@ -1,7 +1,6 @@
 ---
 name: Department of Health and Human Services
 slug: health-human-services
-data: hhs
 layout: default
 ---
      {% include charts.html %}

--- a/_agencies/homeland-security.html
+++ b/_agencies/homeland-security.html
@@ -1,7 +1,6 @@
 ---
 name: Department of Homeland Security
 slug: homeland-security
-data: dhs
 layout: default
 ---
      {% include charts.html %}

--- a/_agencies/housing-urban-development.html
+++ b/_agencies/housing-urban-development.html
@@ -1,7 +1,6 @@
 ---
 name: Department of Housing and Urban Development
 slug: housing-urban-development
-data: hud
 layout: default
 ---
      {% include charts.html %}

--- a/_agencies/interior.html
+++ b/_agencies/interior.html
@@ -1,7 +1,6 @@
 ---
 name: Department of the Interior
 slug: interior
-data: doi
 layout: default
 ---
       {% include charts.html %}

--- a/_agencies/justice.html
+++ b/_agencies/justice.html
@@ -1,7 +1,6 @@
 ---
 name: Department of Justice
 slug: justice
-data: doj
 layout: default
 ---
       {% include charts.html %}

--- a/_agencies/national-aeronautics-space-administration.html
+++ b/_agencies/national-aeronautics-space-administration.html
@@ -1,7 +1,6 @@
 ---
 name: National Aeronautics and Space Administration
 slug: national-aeronautics-space-administration
-data: nasa
 layout: default
 ---
       {% include charts.html %}

--- a/_agencies/national-archives-records-administration.html
+++ b/_agencies/national-archives-records-administration.html
@@ -1,7 +1,6 @@
 ---
 name: National Archives and Records Administration
 slug: national-archives-records-administration
-data: nara
 layout: default
 ---
       {% include charts.html %}

--- a/_agencies/national-science-foundation.html
+++ b/_agencies/national-science-foundation.html
@@ -1,7 +1,6 @@
 ---
 name: National Science Foundation
 slug: national-science-foundation
-data: nsf
 layout: default
 ---
      {% include charts.html %}

--- a/_agencies/nuclear-regulatory-commission.html
+++ b/_agencies/nuclear-regulatory-commission.html
@@ -1,7 +1,6 @@
 ---
 name: Nuclear Regulatory Commission
 slug: nuclear-regulatory-commission
-data: nrc
 layout: default
 ---
       {% include charts.html %}

--- a/_agencies/office-personnel-management.html
+++ b/_agencies/office-personnel-management.html
@@ -1,7 +1,6 @@
 ---
 name: Office of Personnel Management
 slug: office-personnel-management
-data: opm
 layout: default
 ---
       {% include charts.html %}

--- a/_agencies/small-business-administration.html
+++ b/_agencies/small-business-administration.html
@@ -1,7 +1,6 @@
 ---
 name: Small Business Administration
 slug: small-business-administration
-data: sba
 layout: default
 ---
       {% include charts.html %}

--- a/_agencies/social-security-administration.html
+++ b/_agencies/social-security-administration.html
@@ -1,7 +1,6 @@
 ---
 name: Social Security Administration
 slug: social-security-administration
-data: ssa
 layout: default
 ---
       {% include charts.html %}

--- a/_agencies/veterans-affairs.html
+++ b/_agencies/veterans-affairs.html
@@ -1,7 +1,6 @@
 ---
 name: Department of Veterans Affairs
 slug: veterans-affairs
-data: va
 layout: default
 ---
       {% include charts.html %}

--- a/_data_pages/agency-international-development.html
+++ b/_data_pages/agency-international-development.html
@@ -1,7 +1,6 @@
 ---
 name: Agency for International Development
 slug: agency-international-development
-data: usaid
 layout: default
 ---
 {% include data_download.html %}

--- a/_data_pages/education.html
+++ b/_data_pages/education.html
@@ -1,7 +1,6 @@
 ---
 name: Department of Education
 slug: education
-data: ed
 layout: default
 ---
 {% include data_download.html %}

--- a/_data_pages/environmental-protection-agency.html
+++ b/_data_pages/environmental-protection-agency.html
@@ -1,7 +1,6 @@
 ---
 name: Environmental Protection Agency
 slug: environmental-protection-agency
-data: epa
 layout: default
 ---
 {% include data_download.html %}

--- a/_data_pages/executive-office-president.html
+++ b/_data_pages/executive-office-president.html
@@ -1,7 +1,6 @@
 ---
 name: Executive Office of the President
 slug: executive-office-president
-data: eop
 layout: default
 ---
 {% include data_download.html %}

--- a/_data_pages/general-services-administration.html
+++ b/_data_pages/general-services-administration.html
@@ -1,7 +1,6 @@
 ---
 name: General Services Administration
 slug: general-services-administration
-data: gsa
 layout: default
 ---
 {% include data_download.html %}

--- a/_data_pages/health-human-services.html
+++ b/_data_pages/health-human-services.html
@@ -1,7 +1,6 @@
 ---
 name: Department of Health and Human Services
 slug: health-human-services
-data: hhs
 layout: default
 ---
 {% include data_download.html %}

--- a/_data_pages/homeland-security.html
+++ b/_data_pages/homeland-security.html
@@ -1,7 +1,6 @@
 ---
 name: Department of Homeland Security
 slug: homeland-security
-data: dhs
 layout: default
 ---
 {% include data_download.html %}

--- a/_data_pages/housing-urban-development.html
+++ b/_data_pages/housing-urban-development.html
@@ -1,7 +1,6 @@
 ---
 name: Department of Housing and Urban Development
 slug: housing-urban-development
-data: hud
 layout: default
 ---
 {% include data_download.html %}

--- a/_data_pages/interior.html
+++ b/_data_pages/interior.html
@@ -1,7 +1,6 @@
 ---
 name: Department of the Interior
 slug: interior
-data: doi
 layout: default
 ---
 {% include data_download.html %}

--- a/_data_pages/justice.html
+++ b/_data_pages/justice.html
@@ -1,7 +1,6 @@
 ---
 name: Department of Justice
 slug: justice
-data: doj
 layout: default
 ---
 {% include data_download.html %}

--- a/_data_pages/national-aeronautics-space-administration.html
+++ b/_data_pages/national-aeronautics-space-administration.html
@@ -1,7 +1,6 @@
 ---
 name: National Aeronautics and Space Administration
 slug: national-aeronautics-space-administration
-data: nasa
 layout: default
 ---
 {% include data_download.html %}

--- a/_data_pages/national-archives-records-administration.html
+++ b/_data_pages/national-archives-records-administration.html
@@ -1,7 +1,6 @@
 ---
 name: National Archives and Records Administration
 slug: national-archives-records-administration
-data: nara
 layout: default
 ---
 {% include data_download.html %}

--- a/_data_pages/national-science-foundation.html
+++ b/_data_pages/national-science-foundation.html
@@ -1,7 +1,6 @@
 ---
 name: National Science Foundation
 slug: national-science-foundation
-data: nsf
 layout: default
 ---
 {% include data_download.html %}

--- a/_data_pages/nuclear-regulatory-commission.html
+++ b/_data_pages/nuclear-regulatory-commission.html
@@ -1,7 +1,6 @@
 ---
 name: Nuclear Regulatory Commission
 slug: nuclear-regulatory-commission
-data: nrc
 layout: default
 ---
 {% include data_download.html %}

--- a/_data_pages/office-personnel-management.html
+++ b/_data_pages/office-personnel-management.html
@@ -1,7 +1,6 @@
 ---
 name: Office of Personnel Management
 slug: office-personnel-management
-data: opm
 layout: default
 ---
 {% include data_download.html %}

--- a/_data_pages/small-business-administration.html
+++ b/_data_pages/small-business-administration.html
@@ -1,7 +1,6 @@
 ---
 name: Small Business Administration
 slug: small-business-administration
-data: sba
 layout: default
 ---
 {% include data_download.html %}

--- a/_data_pages/social-security-administration.html
+++ b/_data_pages/social-security-administration.html
@@ -1,7 +1,6 @@
 ---
 name: Social Security Administration
 slug: social-security-administration
-data: ssa
 layout: default
 ---
 {% include data_download.html %}

--- a/_data_pages/veterans-affairs.html
+++ b/_data_pages/veterans-affairs.html
@@ -1,7 +1,6 @@
 ---
 name: Department of Veterans Affairs
 slug: veterans-affairs
-data: va
 layout: default
 ---
 {% include data_download.html %}

--- a/_includes/charts.html
+++ b/_includes/charts.html
@@ -2,12 +2,7 @@
     {% assign data_prefix = 'live' %}
     {% assign entity = "government" %}
   {% else %}
-    {% if page.data %}
-      {% assign data_prefix = page.data %}
-    {% else %}
-      {% assign data_prefix = page.slug %}
-    {% endif %}
-
+    {% assign data_prefix = page.slug %}
     {% assign entity = "agency" %}
   {% endif %}
     <!--

--- a/_includes/data_download.html
+++ b/_includes/data_download.html
@@ -4,13 +4,7 @@
         {% assign entity = "government" %}
       {% else %}
         {% capture page_title %} - {{ page.name }} - Data{% endcapture %}
-
-        {% if page.data %}
-          {% assign data_prefix = page.data %}
-        {% else %}
-          {% assign data_prefix = page.slug %}
-        {% endif %}
-
+        {% assign data_prefix = page.slug %}
         {% assign entity = page.name %}
       {% endif %}
       <section class="width-two-thirds">


### PR DESCRIPTION
This commit updates the analytics reporter so that agencies no longer need to specify a `data` property and a `slug` property. Now only a `slug` property needs to be specified since imminent changes on the reporter will make these values equal.

This changes prepares analytics.usa.gov to respond to the changes in 18f/analytics-reporter#181.