### PR TITLE
Setup continuous deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,15 @@
-language: javascript
-
-git:
-  submodules: false
-sudo: false
-
-script: echo "ran"
-
-branches:
-  except:
-    - test-pr
+language: ruby
+script: bundle exec jekyll build
+deploy:
+  edge: true
+  skip_cleanup: true
+  provider: cloudfoundry
+  username:
+    secure: F1SrnljcQS+Fh62drAbyDyTYPF6RtlCXoARQ/1iZN9Sv3u+CkbCwtXwwi77WRi+zb93WwZCkhZ4XNzW4QRlOnN/GYkhIOBNHTgL9Ff0uK3kycuUiwBnRKVxsDlvUp+e+T3Z6I95wgU8shbwVi0mUCg+7p72jA2HVSn/l0587MLc=
+  password:
+    secure: FRBIlx3lLUSXI4dryd7Cwhxiq8egzf2OjeeAiZDlarBAHkODEXicTsFahg2AmVld65oVy/d0uk2ua4UW7SiZ5KDTkE5VYTzjMLxEi+mKEtMlWbXWtGZcxDk86XKqkKymq/obQiLocL1nGog4yW1vhTlJNB7YP75jCH0MfJovQ/E=
+  api: https://api.fr.cloud.gov
+  organization: gsa-opp-analytics
+  space: analytics-dev
+  on:
+    branch: master

--- a/_config.yml
+++ b/_config.yml
@@ -17,6 +17,7 @@ exclude:
 - requirements.txt
 - system-security-plan.yml
 - manifest.yml
+- vendor
 
 # defaults
 defaults:


### PR DESCRIPTION
This commit sets up continuous deploy with Travis. Whenever a changeset is merged into master, Travis will deploy the changes.

At this time, Travis deploys production and staging simultaneously. The deploy can be configured to have a branch that deploys production and a branch that deploys staging, but that seems like overkill for a static site. If it is a necessity though, I have the configuration on hand and can swap it in.