### PR TITLE
Add codeclimate and ESList configs

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,21 @@
+engines:
+  csslinst:
+    enabled: true
+  eslint:
+    enabled: true
+  duplication:
+    enabled: true
+    config:
+      languages:
+      - javascript
+  fixme:
+    enabled: true
+exclude_paths:
+- "**/vendor/**/*"
+- "sass/bourbon/**/*"
+- "sass/neat/**/*"
+ratings:
+  paths:
+  - "**.js"
+  - "**.css"
+  - "**.scss"

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,0 +1,1 @@
+extends: airbnb

--- a/_config.yml
+++ b/_config.yml
@@ -18,6 +18,8 @@ exclude:
 - system-security-plan.yml
 - manifest.yml
 - vendor
+- .codeclimate.yml
+- .eslinrc.yml
 
 # defaults
 defaults:


### PR DESCRIPTION
This commit adds configuration files for Code Climate and ESLint. These configs tell Code Climate to use the ESLint and CSSLint engines. Additionally, it tells Code Climate to ignore vendored JS and CSS.

The ESLint configs present in this commit simply tell ESLint to use the AirBnB config with no overrides.