### PR TITLE
Remove what appears to be a debugging statement.

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -481,7 +481,6 @@
    * ```
    */
   function renderBlock() {
-    console.log("got to start of renderBlock");
     var url = function(d) {
           return d && d.source;
         },


### PR DESCRIPTION
Looks like this `console.log` was introduced in https://github.com/18F/analytics.usa.gov/commit/fda2c7ae2ce94a64de3ece67646940f26756a93f (https://github.com/18F/analytics.usa.gov/pull/404) by @rogeruiz. 

It seems unrelated to the code changes, and therefore likely committed by mistake. 

🚯 