### PR TITLE
Updating total number from all-sites report

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -7,7 +7,7 @@
           </p>
 
           <p>
-            Not every government website is represented in this data. Currently, the Digital Analytics Program collects web traffic from around <a href="https://analytics.usa.gov/data/live/second-level-domains.csv" class="external-link">400 executive branch government domains</a>, across <a href="https://analytics.usa.gov/data/live/sites.csv" class="external-link">about 6000 total websites</a>, including every cabinet department. We continue to pursue and add more sites frequently; to add your site, <a href="mailto:DAP@support.digitalgov.gov" class="external-link">email the Digital Analytics Program</a>.
+            Not every government website is represented in this data. Currently, the Digital Analytics Program collects web traffic from around <a href="https://analytics.usa.gov/data/live/second-level-domains.csv" class="external-link">400 executive branch government domains</a>, across <a href="https://analytics.usa.gov/data/live/sites.csv" class="external-link">about 4500 total websites</a>, including every cabinet department. We continue to pursue and add more sites frequently; to add your site, <a href="mailto:DAP@support.digitalgov.gov" class="external-link">email the Digital Analytics Program</a>.
           </p>
 
 


### PR DESCRIPTION
After adjusting the threshold for the all-sites report to >9, the number moves back to around 4500 non staging, non-spurious sites.