### PR TITLE
Add site wide error banner

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -54,6 +54,12 @@ data_url: https://analytics.usa.gov/data
 # twitter information
 twitter: usgsa
 
+# Site wide error message
+site_wide_error:
+  display: true
+  title: "Issues with the underlying Google Analytics reports"
+  body: "We're having some issues with the underlying Google Analytics reports that are affecting the hourly chart. Thank you for your patience while this is resolved."
+
 sass:
   sass_dir: sass
   style: nested

--- a/_includes/charts.html
+++ b/_includes/charts.html
@@ -21,8 +21,6 @@
       </section>
       -->
       <div id="main_data" class="width-two-thirds">
-        {% include error.html %}
-
         <section id="realtime"
           data-block="realtime"
           data-source="{{ site.data_url }}/{{ data_prefix }}/realtime.json"

--- a/_includes/error.html
+++ b/_includes/error.html
@@ -1,12 +1,12 @@
- <!--        <style>
-          .technical-difficulties {
-            color: #981b1e;
-            background: #fff;
-            padding-top: 1.25em;
-          }
-        </style>
-
-        <div class="technical-difficulties">
-          * We are currently experiencing technical difficulties with respect to our real-time traffic data. 
-          Actual real-time visitor counts may be higher than displayed.
-        </div> -->
+{% if site.site_wide_error.display %}
+  <div class="usa-alert usa-alert-warning" id="site-wide-alert" role="alert">
+    <div class="usa-alert-body">
+      <h3 class="usa-alert-heading">
+        {{ site.site_wide_error.title }}
+      </h3>
+      <p class="usa-alert-text">
+        {{ site.site_wide_error.body }}
+      </p>
+    </div>
+  </div>
+{% endif %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -41,6 +41,8 @@
     </header>
     <div class="container">
 
+      {% include error.html %}
+
       {{ content }}
 
     </div>

--- a/css/public_analytics.scss
+++ b/css/public_analytics.scss
@@ -719,6 +719,10 @@ g.axis {
   }
 }
 
+#site-wide-alert {
+  margin-top: 0;
+}
+
 // nested charts
 figure figure {
   // margin-left: 2rem;


### PR DESCRIPTION
This commit adds a banner to the site which displays an error message when there are issues. The error is controlled using the `site_wide_error` property in the `_config.yml`. The property is an object with the following keys:

- `display`: Whether or not the banner should be displayed
- `title`: The title of the error message
- `body`: The body of the error message

Ref #452