### PR TITLE
Remove the error message about the hourly chart

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -56,9 +56,9 @@ twitter: usgsa
 
 # Site wide error message
 site_wide_error:
-  display: true
-  title: "Issues with the underlying Google Analytics reports"
-  body: "We're having some issues with the underlying Google Analytics reports that are affecting the hourly chart. Thank you for your patience while this is resolved."
+  display: false
+  title: "Error message title here"
+  body: "Put the error message body here"
 
 sass:
   sass_dir: sass


### PR DESCRIPTION
The hourly chart appears to be working again. This commit removes the error message broadcasting that it is broken.