### PR TITLE
Capitalize the first letter of the devices list.

### DIFF
--- a/css/public_analytics.scss
+++ b/css/public_analytics.scss
@@ -427,8 +427,13 @@ section {
   }
 }
 
-#devices p {
-  font-size: 1.3rem;
+#devices {
+  p {
+    font-size: 1.3rem;
+  }
+  .label::first-letter {
+    text-transform: uppercase;
+  }
 }
 
 .downloads {


### PR DESCRIPTION
This PR uses CSS to change the devices breakdown (mobile, desktop, tablet) to title case — as the other breakdowns are. It’s been bothering me. 😅 

I took a look at changing this further upstream, but it seems that these are aggregated in a different place and that seemed like a Big Change for something that was a Small Bother — let me know if you’d rather I pursued that approach! 

## Before:

![Screenshot of analytics.usa.gov with lowercase device breakdown](https://cloud.githubusercontent.com/assets/14930/25090591/20042058-2352-11e7-915a-429bc718aabb.png)

## After:

![Screenshot of analytics.usa.gov with title case device breakdown](https://cloud.githubusercontent.com/assets/14930/25090598/2a75ca96-2352-11e7-833e-152efc471658.png)
