### PR TITLE
Stop docker-compose before building site

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ script:
   - make docker-build-app
   - make docker-build-jekyll-dist
   - make docker-build-production
+  - docker-compose down -v
+  - sudo rm -rf _site/
   - bundle exec jekyll build
 
 deploy:


### PR DESCRIPTION
Docker Compose mounts the site when working with it it. This leads to errors with syscalls when CI tries to build the site without Docker Compose. This commit resolves those issues by stopping Docker Compose before building the site, and then removing the files it has created.