### PR TITLE
Update production Docker image to use custom nginx config

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+.gitignore

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ script:
   - docker-compose up -d && docker-compose exec jekyll bash -c "bundle exec jekyll build"
   - make docker-start
   - make docker-build-app
-  - make docker-build-jekyll-dist
   - make docker-build-production
   - docker-compose down -v
   - sudo rm -rf _site/

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -1,2 +1,25 @@
-FROM nginx:1.11.13-alpine
-COPY dist /usr/share/nginx/html
+FROM nginx:1.13.0
+
+# Install ruby and bundler
+RUN apt-get update
+RUN apt-get install -y build-essential ruby2.3-dev
+RUN gem install bundler
+
+# Add site files
+COPY . /src
+
+# Setup App Root
+RUN mkdir /app \
+    mkdir -p /app/nginx/logs/ \
+    mkdir -p /app/nginx/conf
+
+# Build the site
+RUN cd /src && \
+    bundle install && \
+    bundle exec jekyll build --destination /app/public
+
+# Set defaults for environment in nginx.conf
+ENV APP_ROOT /app
+ENV PORT 80
+
+CMD erb /src/nginx.conf > /etc/nginx/nginx.conf && nginx

--- a/Makefile
+++ b/Makefile
@@ -4,11 +4,8 @@ endif
 ifndef APP_TAG
 	APP_TAG = latest
 endif
-ifndef PROD_IMAGE
-	PROD_IMAGE = 18f/nginx-analytics
-endif
 ifndef PROD_TAG
-	PROD_TAG = latest
+	PROD_TAG = production
 endif
 
 production:
@@ -35,11 +32,8 @@ docker-start:
 docker-build-app:
 	docker build -t $(APP_IMAGE):${APP_TAG} .
 
-docker-build-jekyll-dist:
-	docker run --rm -v $${PWD}/dist:/dist $(APP_IMAGE):${APP_TAG} jekyll build --destination /dist
-
 docker-build-production:
-	docker build -t $(PROD_IMAGE):${PROD_TAG} -f Dockerfile.production .
+	docker build -t $(APP_IMAGE):${PROD_TAG} -f Dockerfile.production .
 
 docker-cli: docker-start
 	docker-compose exec jekyll bash

--- a/README.md
+++ b/README.md
@@ -144,10 +144,16 @@ _NOTE_: 18F does not use Docker in production!
 If you are using Docker in production and you want to deploy just the static pages, you can build an nginx container with the static files built in, running the following command:
 
 ```bash
-make docker-build-production PROD_IMAGE=yourvendor/your-image-name PROD_TAG=latest
+make docker-build-production PROD_IMAGE=yourvendor/your-image-name PROD_TAG=production
 ```
 
-The resulting image will be a standard nginx server image that you can safely push and deploy to your server.
+The resulting image will be an nginx server image that you can safely push and deploy to your server.
+
+The image accepts an environemnt variable to specify the S3 URL that data at `/data/*` is served from:
+
+```
+docker run -p 8080:80 -e S3_BUCKET_URL=https://s3-us-gov-west-1.amazonaws.com/your-s3-bucket/data yourvendor/your-image-name:production
+```
 
 ### Building & Pushing Docker Images
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -30,6 +30,7 @@ http {
     # Note: .+ instead of .*
     # this is to allow /data/ to pass through untouched
 
+    <% if ENV["S3_BUCKET_URL"] %>
     location ~* ^/data/(.+) {
 
       set $url_full         '$1';
@@ -48,8 +49,9 @@ http {
       add_header             Cache-Control "no-cache";
       add_header             Pragma "no-cache";
 
-      proxy_pass             https://s3-us-gov-west-1.amazonaws.com/cg-ff27f612-cd16-4a76-94f8-628986af2158/data/$url_full;
+      proxy_pass             <%= ENV["S3_BUCKET_URL"] %>/$url_full;
     }
+    <% end %>
 
     location / {
       root <%= ENV["APP_ROOT"] %>/public;


### PR DESCRIPTION
This commit updates the Dockerfile for the production Docker image so that is uses the nginx config in the repo.

The nginx config had to be modified a bit to make this possible. Specifically, an environment variable named `S3_BUCKET_URL`. This is the url for the data in the S3 bucket. This is done so the Docker image can handle this proxying action itself, instead of needing an nginx or apache config outside the container to handle this.

Since the nginx conf depends on the environment, it needs to be built at runtime with erb meaning ruby needed to be added to the container. Since ruby was added to the container, I went ahead and moved the site build into the container as well.