### PR TITLE
removing if=government filter for extra blub

### DIFF
--- a/_includes/charts.html
+++ b/_includes/charts.html
@@ -161,7 +161,7 @@
             data-source="{{ site.data_url }}/{{ data_prefix }}/top-pages-realtime.json"
             data-refresh="15">
             <h5><em>
-              People on a <strong>single, specific page</strong> now. {% if entity == "government" %}We only count pages with at least 10 people on the page.{% endif %}
+              People on a <strong>single, specific page</strong> now. We only count pages with at least 10 people on the page.
               <a href="{{ site.data_url }}/{{ data_prefix }}/all-pages-realtime.csv">Download the full dataset.</a>
             </em></h5>
             <div class="data bar-chart">


### PR DESCRIPTION
Addresses https://github.com/18F/analytics.usa.gov/issues/446.  

@jmhooper - just to confirm, does this look okay to you and does it make sense given what we return for the agency pages?  

If so, game to review and merge?