### PR TITLE
Redirect /developers to /developer

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -53,6 +53,10 @@ http {
     }
     <% end %>
 
+    location =/developers {
+      return 302 /developer;
+    }
+
     location / {
       root <%= ENV["APP_ROOT"] %>/public;
       index index.html index.htm Default.htm;


### PR DESCRIPTION
This commit modifies the NGINX configuration so that request to `/developers` redirect to `/developer`.

Closes #456