### PR TITLE
Remove docker compose steps from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,8 @@ services:
   - docker
 
 script:
-  - docker-compose up -d && docker-compose exec jekyll bash -c "bundle exec jekyll build"
-  - make docker-start
   - make docker-build-app
   - make docker-build-production
-  - docker-compose down -v
-  - sudo rm -rf _site/
   - bundle exec jekyll build
 
 deploy:


### PR DESCRIPTION
This commit removes the scripts that fire up Docker Compose from the Travis scripts because they were creating issues with CI/CD.

@gbinal: This should fix the issue we've had with CI deploying the site after merge.