### PR TITLE
Set gzip_vary to on to enable cli clients

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -17,6 +17,7 @@ http {
   gzip_buffers 16 8k;
   gzip_proxied any;
   gzip_types text/plain text/css text/js text/xml text/javascript application/javascript application/x-javascript application/json application/xml application/xml+rss;
+  gzip_vary on;
 
   tcp_nopush on;
   keepalive_timeout 30;


### PR DESCRIPTION
This may need to be explicitly defined, and could potentially cause CLI clients such as wget / curl to not be able to download `csv` files.   I would recommend deploying this to dev and using 'wget' against it to check if the setting works.

It is recommended to switch to the nginx buildpack: https://github.com/cloudfoundry/nginx-buildpack but this might be a good temporary fix while the new buildpack matures .
