### PR TITLE
Updating count of tracked websites from 4,500 to 5,700

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -7,7 +7,7 @@
           </p>
 
           <p>
-            Not every government website is represented in this data. Currently, the Digital Analytics Program collects web traffic from around <a href="https://analytics.usa.gov/data/live/second-level-domains.csv" class="external-link">400 executive branch government domains</a>, across <a href="https://analytics.usa.gov/data/live/sites.csv" class="external-link">about 4500 total websites</a>, including every cabinet department. We continue to pursue and add more sites frequently; to add your site, <a href="mailto:DAP@support.digitalgov.gov" class="external-link">email the Digital Analytics Program</a>.
+            Not every government website is represented in this data. Currently, the Digital Analytics Program collects web traffic from around <a href="https://analytics.usa.gov/data/live/second-level-domains.csv" class="external-link">400 executive branch government domains</a>, across <a href="https://analytics.usa.gov/data/live/sites.csv" class="external-link">about 5,700 total websites</a>, including every cabinet department. We continue to pursue and add more sites frequently; to add your site, <a href="mailto:DAP@support.digitalgov.gov" class="external-link">email the Digital Analytics Program</a>.
           </p>
 
 


### PR DESCRIPTION
This updates this part of the footer, which currently says it tracks 4,500 websites:

<img width="881" alt="screen shot 2018-05-28 at 9 27 03 pm" src="https://user-images.githubusercontent.com/4592/40633457-da3b473e-62bd-11e8-80a6-f560a12bb224.png">


As of right now, it's 5,781 websites that appear in https://analytics.usa.gov/data/live/sites.csv (which is filtered to a certain threshold of visits). Without the threshold, there's 7,217 unique hostnames with at least 1 visit in the last 14 days, but I assume we're describing the count with the threshold.
