### PR TITLE
Lower display threshold for Windows versions from 1% to 0.1%

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -150,7 +150,7 @@
       .transform(function(d) {
         var values = listify(d.totals.os_version),
             total = d3.sum(values.map(function(d) { return d.value; }));
-        return addShares(collapseOther(values, total * .01)); // % of Windows
+        return addShares(collapseOther(values, total * .001)); // % of Windows
       })
       .render(barChart()
         .value(function(d) { return d.share * 100; })


### PR DESCRIPTION
This shows a few more Windows versions that are now below 1%, but still relevant to the thinking of site owners and users:

<img width="851" alt="screen shot 2018-07-09 at 1 04 44 pm" src="https://user-images.githubusercontent.com/4592/42465006-c8d1e242-8378-11e8-9cb8-fd4f4daf347a.png">

The additional rows extend that column, without lengthening the overall section (the Browsers column is still longer).

This is what it shows now on analytics.usa.gov, which leaves out Windows 8, XP, and Vista:

<img width="285" alt="screen shot 2018-07-09 at 1 05 57 pm" src="https://user-images.githubusercontent.com/4592/42465047-e39f9024-8378-11e8-8960-776241b9cd9a.png">
