### PR TITLE
Upgrade to clinuxfs3

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -3,6 +3,8 @@ applications:
 - name: analytics
   memory: 128M
   buildpack: staticfile_buildpack
+  stack: cflinuxfs3
 - name: analytics-staging
   memory: 128M
   buildpack: staticfile_buildpack
+  stack: cflinuxfs3


### PR DESCRIPTION
Bret sent me a form email that cloud.gov was going to stop supporting cflinuxfs2 in late May and that we should upgrade. This commit does that upgrade.
