### PR TITLE
Adding the sitewide error banner

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -58,9 +58,9 @@ twitter: usgsa
 
 # Site wide error message
 site_wide_error:
-  display: false
-  title: "This site is not being updated and may not be accurate"
-  body: "Due to a lapse in government funding, analytics.usa.gov will not be updated until further notice. Updates regarding government operating status and resumption of normal operations can be found at usa.gov."
+  display: true
+  title: "Some pages are not being updated and may not be accurate"
+  body: "Due to abnormally high traffic today, the Google Analytics account that powers this dashboard has encountered an error. As a result, the analytics.usa.gov homepage and the Department of Treasury page are temporarily frozen and not updating. We apologize, and hope it will be resolved soon."
 
 sass:
   sass_dir: sass


### PR DESCRIPTION
The massive amount of traffic to IRS today seems to have broken the GA realtime reports. Adding the banner to alert visitors.



