### PR TITLE
Add second instance

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,6 +1,7 @@
 ---
 applications:
 - name: analytics
+  instances: 2
   memory: 128M
   buildpack: staticfile_buildpack
   stack: cflinuxfs3


### PR DESCRIPTION
Adding a second instance as a production best practice. This should prevent downtime during deploy.

This might have already been applied via `cf scale` or within the cloud.gov dashboard, but this will make it explicit.

## This pull request is ready to merge when...
- [x] Tests have been updated (and all tests are passing)
- [x] This code has been reviewed by someone other than the original author
- [x] The change has been documented

