### PR TITLE
Activating sitewide banner

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -58,9 +58,9 @@ twitter: usgsa
 
 # Site wide error message
 site_wide_error:
-  display: false
-  title: "Some pages may not be updated and may not be accurate"
-  body: "Due to an extremely large recent increase in traffic, the Google Analytics account that powers this dashboard has been experiencing intermittent errors. As a result, the realtime reports may not be reflective of the most recent attempt to fetch the data. We are working to ensure future accuracy and consistency, and apologize for the issue."
+  display: true
+  title: "Realtime data may not be accurate"
+  body: "The Google Analytics account that powers this dashboard is currently experiencing issues with realtime reporting. As a result, the realtime reports may not be accurate."
 sass:
   sass_dir: sass
   style: nested


### PR DESCRIPTION
Realtime data in the Z3 View of the DAP GA account that powers the data on the analytics.usa.gov homepage is currently incorrect. This banner will alert users.
