### PR TITLE
Reduce Dependabot noise to once a week

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+- package-ecosystem: npm
+  directory: "/"
+  schedule:
+    interval: weekly
+    day: "wednesday"
+    time: "09:00"
+    timezone: 'America/New_York'
+  open-pull-requests-limit: 10
+- package-ecosystem: bundler
+  directory: "/"
+  schedule:
+    interval: weekly
+    day: "wednesday"
+    time: "09:00"
+    timezone: 'America/New_York'
+  open-pull-requests-limit: 5


### PR DESCRIPTION
Day and hour that updates occur can be tweaked to your needs:

https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/configuration-options-for-dependency-updates#scheduleday



