### PR TITLE
Adds ability to view individual cfpb reports

### DIFF
--- a/_agencies/cfpb.html
+++ b/_agencies/cfpb.html
@@ -1,0 +1,6 @@
+---
+name: Consumer Financial Protection Bureau
+slug: cfpb
+layout: default
+---
+{% include charts.html %}

--- a/_data_pages/cfpb.html
+++ b/_data_pages/cfpb.html
@@ -1,0 +1,6 @@
+---
+name: Consumer Financial Protection Bureau
+slug: cfpb
+layout: default
+---
+{% include data_download.html %}


### PR DESCRIPTION
## Summary
The cfpb is a DAP partner and available in the "all participating websites" section. Once https://github.com/18F/analytics-reporter/pull/646 is merged, individual reports will be available for the cfpb, which this PR reveals by adding the proper `_agencies` and `_data_pages` files.


## Impacted Areas of the Site
  - cfpb option added to the dropdown
  - cfpb individual reports page
 
## Optional Screenshots

<img width="1670" alt="Screen Shot 2022-02-09 at 7 41 11 PM" src="https://user-images.githubusercontent.com/1558033/153445251-89bd2554-95e9-4b55-b209-114a25125236.png">


## This pull request is ready to merge when...
- [ ] https://github.com/18F/analytics-reporter/pull/646 is merged and deployed
- [ ] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
- [ ] The change has been documented

