### PR TITLE
Copy change for warning banner

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -41,8 +41,8 @@ defaults:
       layout: default
 
 # Site title and description
-title: "analytics.usa.gov | The US government's web traffic."
-description: "Official data on web traffic to hundreds of US federal government websites. Published by the Digital Analytics Program."
+title: "analytics.usa.gov | The US government's web traffic. Analytics.usa.gov is migrating to a new web analytics platform."
+description: "Official data on web traffic to hundreds of US federal government websites. Published by the Digital Analytics Program. Real time data is currently unavailable."
 
 # Site's own URL
 url: https://analytics.usa.gov

--- a/_config.yml
+++ b/_config.yml
@@ -60,7 +60,7 @@ twitter: usgsa
 site_wide_error:
   display: true
   title: "Data May Be Unavailable Due to a Planned Website Upgrade."
-  body: "Analytics.usa.gov is undergoing scheduled infrastructure and software upgrades. Real time data and associated reports may be temporarily unavailable."
+  body: "Analytics.usa.gov is migrating to a new web analytics platform. Real time data is currently unavailable."
 sass:
   sass_dir: sass
   style: nested

--- a/_config.yml
+++ b/_config.yml
@@ -42,7 +42,7 @@ defaults:
 
 # Site title and description
 title: "analytics.usa.gov | The US government's web traffic. Analytics.usa.gov is migrating to a new web analytics platform."
-description: "Official data on web traffic to hundreds of US federal government websites. Published by the Digital Analytics Program. Real time data is currently unavailable."
+description: "Official data on web traffic to thousands of US federal government websites. Published by the Digital Analytics Program. Real time data is currently unavailable."
 
 # Site's own URL
 url: https://analytics.usa.gov


### PR DESCRIPTION
## Summary
Updates copy for global warning message.

<img width="1679" alt="Screen Shot 2023-10-04 at 4 20 05 PM" src="https://github.com/18F/analytics.usa.gov/assets/104778659/b94d2189-59a8-4df8-9473-ec6f14d3703e">


## This pull request is ready to merge when...
- [x] The change has been documented

