### PR TITLE
Restore local data

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,40 +1,38 @@
-
 baseurl: ""
 
 # Don't exclude nginx.conf, needs to be copied into _site for
 # cloud.gov to pick up on it.
 exclude:
-- .gitignore
-- .codeclimate.yml
-- .eslinrc.yml
-- .sass-cache
-- bin/
-- docs/
-- fake-data/
-- node_modules/
-- sass/
-- spec/
-- CONTRIBUTING.md
-- Dockerfile
-- Dockerfile.production
-- docker-compose.yml
-- Gemfile
-- Gemfile.lock
-- LICENSE.md
-- Makefile
-- manifest.yml
-- nginx.conf
-- package.json
-- package-lock.json
-- README.md
-- Staticfile
-- system-security-plan.yml
-- vendor
-- webpack.config.js
+  - .gitignore
+  - .codeclimate.yml
+  - .eslinrc.yml
+  - .sass-cache
+  - bin/
+  - docs/
+  - fake-data/
+  - node_modules/
+  - sass/
+  - spec/
+  - CONTRIBUTING.md
+  - Dockerfile
+  - Dockerfile.production
+  - docker-compose.yml
+  - Gemfile
+  - Gemfile.lock
+  - LICENSE.md
+  - Makefile
+  - manifest.yml
+  - nginx.conf
+  - package.json
+  - package-lock.json
+  - README.md
+  - Staticfile
+  - system-security-plan.yml
+  - vendor
+  - webpack.config.js
 
 defaults:
-  -
-    scope:
+  - scope:
       path: ""
       type: agencies
     values:

--- a/_config.yml
+++ b/_config.yml
@@ -9,7 +9,6 @@ exclude:
   - .sass-cache
   - bin/
   - docs/
-  - fake-data/
   - node_modules/
   - sass/
   - spec/


### PR DESCRIPTION
## Summary

**Fake data is available for local development.** Restores fake data for local development. 

## Impacted Areas of the Site

All environments. Unblocks local development, but impacts non-dev environments because these files are included.

### Todo

Need to create a follow-up issue for excluding fake data on production.

## Optional Screenshots

**Before** - Excluding fake data

Uncomment line 4 in `_development.yml` and run `make dev`. Fake data doesn't load and a lot of `404` messages appear in console.

<img width="1000" alt="image" src="https://github.com/18F/analytics.usa.gov/assets/3385219/932b0386-d0b1-4f01-bac8-6c823b95d195">

**After**

After removing `fake-data` for exclusion we can see 404's are gone and site loads properly.

<img width="1000" alt="image" src="https://github.com/18F/analytics.usa.gov/assets/3385219/0f0138a3-7dfd-4445-adbb-fbd53ee7af30">


## How to test

1. Checkout this feature branch `jm-restore-local-data`.
2. Uncomment line 4 in `_development.yml`.
3. In terminal run `make dev` to run local environment.
4. Visit `localhost:4000`.
5. Site should load as expected with fake data.

## This pull request changes...

- [ ] Jekyll config [`_config.yml`]


## This pull request is ready to merge when...
- [ ] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
- [ ] The change has been documented

