### PR TITLE
Add GitHub Action to open reminder issue for log checks

### DIFF
--- a/.github/workflows/log_check_reminder.yml
+++ b/.github/workflows/log_check_reminder.yml
@@ -1,0 +1,24 @@
+name: Weekly Reminder to Check Logs for Errors/Security Issues.
+
+# on:
+  # schedule:
+    # - cron: '0 0 * * 3' 
+on:
+  workflow_dispatch:
+
+jobs:
+  #Add Reminder issue to github issues on analytics.usa.gov repo.
+  add_reminder:    
+    runs-on: ubuntu-latest
+    environment: develop
+    
+    steps:
+              
+      - name: Open Issue Action
+        uses: GuillaumeFalourd/open-issue-action@v1
+        with: 
+          access-token: ${{ secrets.ACCESS_TOKEN }}
+          repo-owner: 18F
+          repo-name: analytics.usa.gov
+          issue-title: First Test
+          issue-body: First Test


### PR DESCRIPTION
## Summary
This PR is the first to implement an automated scheduled reminder issue to open every Wednesday night at midnight to check the logs for security issues and other errors. This is a POAM.

*Describe the pull request here, including any supplemental information needed to understand it.*

## Impacted Areas of the Site
None except for github actions

## Optional Screenshots

## This pull request changes...
- Adds a GitHub action which must be in develop before we can test.



