### PR TITLE
Add GitHub Action to open reminder issue for log checks 2

### DIFF
--- a/.github/workflows/log_check_reminder.yml
+++ b/.github/workflows/log_check_reminder.yml
@@ -1,10 +1,8 @@
 name: Weekly Reminder to Check Logs for Errors/Security Issues.
 
-# on:
-  # schedule:
-    # - cron: '0 0 * * 3' 
 on:
-  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * 3' 
 
 jobs:
   #Add Reminder issue to github issues on analytics.usa.gov repo.
@@ -20,5 +18,5 @@ jobs:
           access-token: ${{ secrets.ACCESS_TOKEN }}
           repo-owner: 18F
           repo-name: analytics.usa.gov
-          issue-title: First Test
-          issue-body: First Test
+          issue-title: REMINDER! Scan Logs for Security Issues and Other errors.
+          issue-body: This issue is an automated weekly reminder to review logs for all Analytics systems for any security errors or other errors.


### PR DESCRIPTION
## Summary
Updates the GitHub Action workflow that providers weekly reminders by putting it on the schedule now that it has passed testing.

*Describe the pull request here, including any supplemental information needed to understand it.*

## Impacted Areas of the Site
None

## Optional Screenshots

## This pull request changes...
- GitHub Actions workflow for security log reminder. 

