### PR TITLE
update sessions today data source

### DIFF
--- a/_includes/charts/sessions-today.html
+++ b/_includes/charts/sessions-today.html
@@ -18,7 +18,7 @@
     <section
     id="time_series"
     data-block="today"
-    data-source="{{ site.data_url }}/{{ data_prefix }}/today.json"
+    data-source="{{ site.data_url }}/{{ data_prefix }}/last-48-hrs.json"
     data-refresh="15"
   >
     <svg class="data time-series"></svg>

--- a/_includes/charts/sessions-today.html
+++ b/_includes/charts/sessions-today.html
@@ -18,7 +18,7 @@
     <section
     id="time_series"
     data-block="today"
-    data-source="{{ site.data_url }}/{{ data_prefix }}/last-48-hrs.json"
+    data-source="{{ site.data_url }}/{{ data_prefix }}/last-48-hours.json"
     data-refresh="15"
   >
     <svg class="data time-series"></svg>


### PR DESCRIPTION
## Summary
This updates the data source for the today sessions to use an order array of values from `last-48-hours.json` report rather than `today.json`

## Background

Sampling level is automatic | today, top-pages-7-days | We can’t adjust precision in sampling, but we still get a metadata response when sampling has been performed.In some cases sampling is done while processing is still in progress, so !Golden.  When this occurs GA4 buckets values into the “(other)” key.  For reports like today, with date rage “today” -> “today” this makes a significant impact.  By updating the report date range to start from “yesterday”, we get a much more accurate SUM value, but need to handle some data clean-up on FE rendering.
-- | -- | --


## To test this change
- [ ]  pull work locally
- [ ] include the attached `last-48-hours.json` report in the `ga4-data` directory and update `_devlopment.yml` accordingly
- [ ] build project
- [ ] inspect DOM to ensure that element is sourcing report as expected
- [ ] confirm elements are rendering

## This pull request is ready to merge when...
- [ ] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
- [ ] The change has been documented

