### PR TITLE
Update chart copy

### DIFF
--- a/_includes/charts/locations.html
+++ b/_includes/charts/locations.html
@@ -1,6 +1,6 @@
 <section class="locations" id="locations">
   <section class="section_headline">
-    <h3>User Locations In The Last 30 Minutes</h3>
+    <h3>User Locations and Languages Now</h3>
   </section>
 
   <div class="grid-row">

--- a/_includes/charts/sessions-90-days.html
+++ b/_includes/charts/sessions-90-days.html
@@ -1,11 +1,11 @@
 <section>
   <section class="section_headline">
-    <h3>Sessions in the Past 30 Days</h3>
+    <h3>Sessions in the Past 90 Days</h3>
   </section>
 
   <section class="section_subheadline">
     There were <span id="total_visitors" class="data">...</span> sessions over the
-    past 30 days.
+    past 90 days.
   </section>
 
   <section class="grid-row">

--- a/_includes/charts/sessions-today.html
+++ b/_includes/charts/sessions-today.html
@@ -8,12 +8,12 @@
     <h2 class="chart-realtime__current_visitors data">...</h2>
     <div class="chart-realtime__description">
       people on government websites <br />
-      and apps in last 30 minutes
+      and apps now
     </div>
   </section>
 
   <section class="section_headline visits_today">
-    <h3>Sessions Today</h3>
+    <h3>Daily Sessions in the Past 30 Days</h3>
     <h4>Eastern Time</h4>
     <section
     id="time_series"

--- a/_includes/data_download.html
+++ b/_includes/data_download.html
@@ -50,7 +50,7 @@
       </thead>
       <tbody>
         <tr>
-          <td>Sessions to all hostnames over 30 days</td>
+          <td>Sessions to all hostnames over 90 days</td>
           <td>
             <a
               href="{{ site.data_url }}/{{ data_prefix }}/all-domains-30-days.csv"
@@ -72,7 +72,7 @@
           <td>Daily</td>
         </tr>
         <tr>
-          <td>Top traffic sources (30 days)</td>
+          <td>Top traffic sources (90 days)</td>
           <td>
             <a
               href="{{ site.data_url }}/{{ data_prefix }}/top-traffic-sources-30-days.csv"
@@ -88,7 +88,7 @@
           <td>Daily</td>
         </tr>
         <tr>
-          <td>Top exit pages (30 days)</td>
+          <td>Top exit pages (90 days)</td>
           <td>
             <a
               href="{{ site.data_url }}/{{ data_prefix }}/top-exit-pages-30-days.csv"


### PR DESCRIPTION
## Summary
Update copy to read 90 days for reporting where applicable.

## Impacted Areas of the Site

**data downloads**
<img width="1164" alt="Screen Shot 2024-01-16 at 9 27 06 AM" src="https://github.com/18F/analytics.usa.gov/assets/104778659/ceba2235-dfdc-460b-9009-cc903383b9d6">

**sessions**
<img width="1117" alt="Screen Shot 2024-01-16 at 9 28 32 AM" src="https://github.com/18F/analytics.usa.gov/assets/104778659/672ce9fd-898d-4215-8473-4cf425e14476">

**top pages**
@smarina04 Still keep this at 30 days?
<img width="573" alt="Screen Shot 2024-01-16 at 9 41 17 AM" src="https://github.com/18F/analytics.usa.gov/assets/104778659/fdfccb2d-efeb-4ce6-b044-a5b305dd33b3">

**current visitors and past 30 days for sessions**
<img width="1676" alt="homepage" src="https://github.com/18F/analytics.usa.gov/assets/104778659/987274c8-acb5-42ee-8ff2-1051349cf69d">


****

## This pull request is ready to merge when...
- [ ] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
- [ ] The change has been documented

