### PR TITLE
Adjust text/links for a hotfix

### DIFF
--- a/_includes/charts/top-pages.html
+++ b/_includes/charts/top-pages.html
@@ -30,7 +30,7 @@
       <strong>People</strong> on a <strong>single, specific page or app screen</strong> in
       the last 30 minutes. Hostnames are not currently reported in real-time,
       so only page title and screen name information is available.
-      <a href="{{ site.data_url }}/{{ data_prefix }}/all-pages-realtime.csv">Download the full dataset.</a>
+      <!--<a href="{{ site.data_url }}/{{ data_prefix }}/all-pages-realtime.csv">Download the full dataset.</a>-->
     </p>
     <div class="data bar-chart"></div>
   </figure>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -41,7 +41,7 @@
       <p>
         Due to varying GA4 sampling thresholds, high data cardinality, and the
         volume of DAP data across its sub-properties, real-time and historical
-        data reports are subject to sampling. This data are intended to
+        data reports are subject to sampling. These data are intended to
         represent high-level trends only and provide general insights into
         online visitor behavior.
       </p>


### PR DESCRIPTION
- Fix small grammar issue in the footer.
- Remove the link to download the all-pages-realtime report from the top-pages 30 minutes tab