### PR TITLE
Hotfix to remove total people online report from data page

### DIFF
--- a/_includes/data_download.html
+++ b/_includes/data_download.html
@@ -53,7 +53,7 @@
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <!--<tr>
             <td scope="row">Total people online</td>
             <td>30 minutes</td>
             <td>
@@ -63,9 +63,9 @@
                 aria-label="realtime.csv" disabled="disabled" aria-disabled="true">CSV</a>
             </td>
             <td>Every 30 minutes</td>
-          </tr>
+          </tr>-->
           <tr>
-            <td scope="row">All pages and screens people are viewing</td>
+            <td scope="row">Top pages and screens people are viewing</td>
             <td>30 minutes</td>
             <td>
               <a href="{{ site.data_url }}/{{ data_prefix }}/all-pages-realtime.json" class="download-data usa-button"


### PR DESCRIPTION
Resolves ticket: https://github.com/18F/analytics.usa.gov/issues/1199