### PR TITLE
[Tech Debt] Update CSP to be more restrictive

### DIFF
--- a/nginx.conf.src
+++ b/nginx.conf.src
@@ -53,7 +53,7 @@ http {
       resolver               8.8.8.8 valid=300s;
 
       add_header             Cache-Control "no-cache";
-      add_header             Content-Security-Policy "default-src 'self' https://dap.digitalgov.gov https://www.google-analytics.com https://www.googletagmanager.com https://touchpoints.app.cloud.gov https://cg-1b082c1b-3db7-477f-9ca5-bd51a786b41e.s3-us-gov-west-1.amazonaws.com; form-action 'none'; frame-ancestors 'none';" always;
+      add_header             Content-Security-Policy "default-src 'self'; script-src 'self' https://dap.digitalgov.gov https://www.google-analytics.com https://www.googletagmanager.com https://touchpoints.app.cloud.gov; connect-src 'self' https://www.google-analytics.com https://touchpoints.app.cloud.gov; img-src 'self' https://touchpoints.app.cloud.gov https://cg-1b082c1b-3db7-477f-9ca5-bd51a786b41e.s3-us-gov-west-1.amazonaws.com; form-action 'none'; frame-ancestors 'none';" always;
       add_header             Permissions-Policy "autoplay=(), encrypted-media=(), fullscreen=(), geolocation=(), microphone=(), midi=(), payment=()" always;
       add_header             Pragma "no-cache";
       add_header             Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
@@ -71,7 +71,7 @@ http {
 
       autoindex on;
 
-      #auth_basic "Restricted";                                #For Basic Auth
+      #auth_basic "Restricted";                        #For Basic Auth
       #auth_basic_user_file /home/vcap/app/.htpasswd;  #For Basic Auth
 
       if ($http_x_forwarded_proto != "https") {
@@ -82,7 +82,7 @@ http {
       # Touchpoints and S3 domains are added to the CSP support touchpoints JS
       # code which dynamically adds HTML with images and references JS on the
       # touchpoints server.
-      add_header Content-Security-Policy "default-src 'self' https://dap.digitalgov.gov https://www.google-analytics.com https://www.googletagmanager.com https://touchpoints.app.cloud.gov https://cg-1b082c1b-3db7-477f-9ca5-bd51a786b41e.s3-us-gov-west-1.amazonaws.com; form-action 'none'; frame-ancestors 'none';" always;
+      add_header Content-Security-Policy "default-src 'self'; script-src 'self' https://dap.digitalgov.gov https://www.google-analytics.com https://www.googletagmanager.com https://touchpoints.app.cloud.gov; connect-src 'self' https://www.google-analytics.com https://touchpoints.app.cloud.gov; img-src 'self' https://touchpoints.app.cloud.gov https://cg-1b082c1b-3db7-477f-9ca5-bd51a786b41e.s3-us-gov-west-1.amazonaws.com; form-action 'none'; frame-ancestors 'none';" always;
       add_header Permissions-Policy "autoplay=(), encrypted-media=(), fullscreen=(), geolocation=(), microphone=(), midi=(), payment=()" always;
       add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
       add_header X-Content-Type-Options "nosniff" always;
@@ -90,7 +90,7 @@ http {
     }
 
     location =/developers {
-      add_header Content-Security-Policy "default-src 'self' https://dap.digitalgov.gov https://www.google-analytics.com https://www.googletagmanager.com https://touchpoints.app.cloud.gov https://cg-1b082c1b-3db7-477f-9ca5-bd51a786b41e.s3-us-gov-west-1.amazonaws.com; form-action 'none'; frame-ancestors 'none';" always;
+      add_header Content-Security-Policy "default-src 'self'; script-src 'self' https://dap.digitalgov.gov https://www.google-analytics.com https://www.googletagmanager.com https://touchpoints.app.cloud.gov; connect-src 'self' https://www.google-analytics.com https://touchpoints.app.cloud.gov; img-src 'self' https://touchpoints.app.cloud.gov https://cg-1b082c1b-3db7-477f-9ca5-bd51a786b41e.s3-us-gov-west-1.amazonaws.com; form-action 'none'; frame-ancestors 'none';" always;
       add_header Permissions-Policy "autoplay=(), encrypted-media=(), fullscreen=(), geolocation=(), microphone=(), midi=(), payment=()" always;
       add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
       add_header X-Content-Type-Options "nosniff" always;
@@ -98,7 +98,7 @@ http {
     }
 
     location =/developer {
-      add_header Content-Security-Policy "default-src 'self' https://dap.digitalgov.gov https://www.google-analytics.com https://www.googletagmanager.com https://touchpoints.app.cloud.gov https://cg-1b082c1b-3db7-477f-9ca5-bd51a786b41e.s3-us-gov-west-1.amazonaws.com; form-action 'none'; frame-ancestors 'none';" always;
+      add_header Content-Security-Policy "default-src 'self'; script-src 'self' https://dap.digitalgov.gov https://www.google-analytics.com https://www.googletagmanager.com https://touchpoints.app.cloud.gov; connect-src 'self' https://www.google-analytics.com https://touchpoints.app.cloud.gov; img-src 'self' https://touchpoints.app.cloud.gov https://cg-1b082c1b-3db7-477f-9ca5-bd51a786b41e.s3-us-gov-west-1.amazonaws.com; form-action 'none'; frame-ancestors 'none';" always;
       add_header Permissions-Policy "autoplay=(), encrypted-media=(), fullscreen=(), geolocation=(), microphone=(), midi=(), payment=()" always;
       add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
       add_header X-Content-Type-Options "nosniff" always;


### PR DESCRIPTION
- Move DAP domains and touchpoints from default-src to script-src and img-src.
- Add connect-src to allow connection to Google Analytics and Touchpoints