### PR TITLE
[Feature] Use internal route for API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,8 +68,9 @@ jobs:
     if: github.ref == 'refs/heads/develop'
     uses: 18F/analytics.usa.gov/.github/workflows/deploy.yml@develop
     with:
-      API_DOMAIN: ${{ vars.API_DOMAIN }}
-      API_PATH: ${{ vars.API_PATH_DEV }}
+      API_APP_NAME: ${{ vars.API_APP_NAME_DEV }}
+      API_FQDN: ${{ vars.API_FQDN_DEV }}
+      API_PORT: ${{ vars.API_PORT }}
       APP_NAME: ${{ vars.APP_NAME_DEV }}
       APP_URL: ${{ vars.APP_URL_DEV }}
       CF_ORGANIZATION_NAME: ${{ vars.CF_ORGANIZATION_NAME }}
@@ -78,7 +79,7 @@ jobs:
       S3_BUCKET_URL: ${{ vars.S3_BUCKET_URL_DEV }}
       S3_SERVICE_NAME: ${{ vars.S3_SERVICE_NAME_DEV }}
     secrets:
-      API_KEY: ${{ secrets.API_KEY_DEV }}
+      API_DATA_GOV_SECRET: ${{ secrets.API_DATA_GOV_SECRET_DEV }}
       CF_USERNAME: ${{ secrets.CF_USERNAME_DEV }}
       CF_PASSWORD: ${{ secrets.CF_PASSWORD_DEV }}
       NEW_RELIC_LICENSE_KEY: ${{ secrets.NEW_RELIC_LICENSE_KEY_DEV }}
@@ -90,8 +91,9 @@ jobs:
     if: github.ref == 'refs/heads/staging'
     uses: 18F/analytics.usa.gov/.github/workflows/deploy.yml@develop
     with:
-      API_DOMAIN: ${{ vars.API_DOMAIN }}
-      API_PATH: ${{ vars.API_PATH_STG }}
+      API_APP_NAME: ${{ vars.API_APP_NAME_STG }}
+      API_FQDN: ${{ vars.API_FQDN_STG }}
+      API_PORT: ${{ vars.API_PORT }}
       APP_NAME: ${{ vars.APP_NAME_STG }}
       APP_URL: ${{ vars.APP_URL_STG }}
       CF_ORGANIZATION_NAME: ${{ vars.CF_ORGANIZATION_NAME }}
@@ -100,7 +102,7 @@ jobs:
       S3_BUCKET_URL: ${{ vars.S3_BUCKET_URL_STG }}
       S3_SERVICE_NAME: ${{ vars.S3_SERVICE_NAME_STG }}
     secrets:
-      API_KEY: ${{ secrets.API_KEY_STG }}
+      API_DATA_GOV_SECRET: ${{ secrets.API_DATA_GOV_SECRET_STG }}
       CF_USERNAME: ${{ secrets.CF_USERNAME_STG }}
       CF_PASSWORD: ${{ secrets.CF_PASSWORD_STG }}
       NEW_RELIC_LICENSE_KEY: ${{ secrets.NEW_RELIC_LICENSE_KEY_STG }}
@@ -112,8 +114,9 @@ jobs:
     if: github.ref == 'refs/heads/master'
     uses: 18F/analytics.usa.gov/.github/workflows/deploy.yml@develop
     with:
-      API_DOMAIN: ${{ vars.API_DOMAIN }}
-      API_PATH: ${{ vars.API_PATH_PRD }}
+      API_APP_NAME: ${{ vars.API_APP_NAME_PRD }}
+      API_FQDN: ${{ vars.API_FQDN_PRD }}
+      API_PORT: ${{ vars.API_PORT }}
       APP_NAME: ${{ vars.APP_NAME_PRD }}
       APP_URL: ${{ vars.APP_URL_PRD }}
       CF_ORGANIZATION_NAME: ${{ vars.CF_ORGANIZATION_NAME }}
@@ -122,7 +125,7 @@ jobs:
       S3_BUCKET_URL: ${{ vars.S3_BUCKET_URL_PRD }}
       S3_SERVICE_NAME: ${{ vars.S3_SERVICE_NAME_PRD }}
     secrets:
-      API_KEY: ${{ secrets.API_KEY_PRD }}
+      API_DATA_GOV_SECRET: ${{ secrets.API_DATA_GOV_SECRET_PRD }}
       CF_USERNAME: ${{ secrets.CF_USERNAME_PRD }}
       CF_PASSWORD: ${{ secrets.CF_PASSWORD_PRD }}
       NEW_RELIC_LICENSE_KEY: ${{ secrets.NEW_RELIC_LICENSE_KEY_PRD }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,10 +1,13 @@
 on:
   workflow_call:
     inputs:
-      API_DOMAIN:
+      API_APP_NAME:
         required: true
         type: string
-      API_PATH:
+      API_FQDN:
+        required: true
+        type: string
+      API_PORT:
         required: true
         type: string
       APP_NAME:
@@ -28,7 +31,7 @@ on:
         required: true
         type: string
     secrets:
-      API_KEY:
+      API_DATA_GOV_SECRET:
         required: true
       CF_USERNAME:
         required: true
@@ -37,9 +40,10 @@ on:
       NEW_RELIC_LICENSE_KEY:
 
 env:
-  API_DOMAIN: ${{ inputs.API_DOMAIN }}
-  API_PATH: ${{ inputs.API_PATH }}
-  API_KEY: ${{ secrets.API_KEY }}
+  API_APP_NAME: ${{ inputs.API_APP_NAME }}
+  API_FQDN: ${{ inputs.API_FQDN }}
+  API_DATA_GOV_SECRET: ${{ secrets.API_DATA_GOV_SECRET }}
+  API_PORT: ${{ inputs.API_PORT }}
   APP_NAME: ${{ inputs.APP_NAME }}
   APP_URL: ${{ inputs.APP_URL }}
   CF_USERNAME: ${{ secrets.CF_USERNAME }}
@@ -87,10 +91,6 @@ jobs:
           mv manifest.yml manifest.yml.src
           envsubst < manifest.yml.src > manifest.yml
           cat manifest.yml
-      - name: Run envsubst on nginx.conf to set the API domain, API path, API key, and  S3 bucket URL for the environment
-        run: |
-          envsubst '${API_DOMAIN} ${API_PATH} ${API_KEY} ${S3_BUCKET_URL}' < nginx.conf.src > nginx.conf
-          cat nginx.conf
       - name: Login to cloud.gov and deploy
         run: |
           set -e
@@ -98,4 +98,6 @@ jobs:
           cf api api.fr.cloud.gov
           cf login -u $CF_USERNAME -p $CF_PASSWORD -o $CF_ORGANIZATION_NAME -s $CF_SPACE_NAME
           cf push -f "./manifest.yml"
+          # Add network policy to connect to internal API instance
+          cf add-network-policy $APP_NAME $API_APP_NAME -s $CF_SPACE_NAME -o $CF_ORGANIZATION_NAME --protocol tcp --port $API_PORT
           cf logout

--- a/apt.yml
+++ b/apt.yml
@@ -1,4 +1,0 @@
----
-packages:
-- inotify-tools
-- gettext-base  

--- a/buildpack.yml
+++ b/buildpack.yml
@@ -1,0 +1,3 @@
+---
+nginx:
+  version: mainline

--- a/manifest.yml
+++ b/manifest.yml
@@ -2,13 +2,15 @@ applications:
 - name: ${APP_NAME}
   instances: 1
   memory: 128M
-  buildpacks:
-  - https://github.com/cloudfoundry/apt-buildpack
-  - nginx_buildpack
+  buildpack: nginx_buildpack
   stack: cflinuxfs4
   services:
   - ${S3_SERVICE_NAME}
-  command: "chmod +x ./entrypoint.sh && ./entrypoint.sh"
+  path: .
   env:
+    API_FQDN: ${API_FQDN}
+    API_DATA_GOV_SECRET: ${API_DATA_GOV_SECRET}
+    API_PORT: ${API_PORT}
     NEW_RELIC_APP_NAME: ${NEW_RELIC_APP_NAME}
     NEW_RELIC_LICENSE_KEY: ${NEW_RELIC_LICENSE_KEY}
+    S3_BUCKET_URL: ${S3_BUCKET_URL}

--- a/nginx.conf
+++ b/nginx.conf
@@ -20,7 +20,7 @@ http {
 
   tcp_nopush on;
   keepalive_timeout 30;
-  port_in_redirect off; # Ensure that redirects don't include the internal container PORT - <%= ENV["PORT"] %>
+  port_in_redirect off; # Ensure that redirects don't include the internal container port
   server_tokens off;
 
   map $http_origin $allow_origin {
@@ -31,8 +31,7 @@ http {
   }
 
   server {
-    #listen {{port}};
-    listen 8080;
+    listen {{port}};
     server_name localhost;
 
     # Proxy requests to the DAP API and use an API key which is provided upon
@@ -41,16 +40,19 @@ http {
       set $path                  '$1';
       set $querystring           '$is_args$args';
       gunzip                     on;
+      # The {{nameservers}} is interpolated by the NGINX cloud foundry buildpack
       # When the domain resolves to an IPv6 address, NGINX has an internal error
-      # and returns a 500 response. Disable IPv6, TODO: determine the cause.
-      resolver                   8.8.8.8 ipv6=off valid=300s;
+      # and returns a 500 response. Disable IPv6, TODO: determine the cause for
+      # failures in IPv6.
+      resolver                   {{nameservers}} ipv6=off valid=300s;
       proxy_http_version         1.1;
       proxy_buffering            on;
       proxy_intercept_errors     off;
+      proxy_ssl_server_name      on;
 
       # Set headers on the proxied request to the API
       proxy_set_header           Authorization '';
-      proxy_set_header           x-api-key '${API_KEY}';
+      proxy_set_header           api-data-gov-secret {{env "API_DATA_GOV_SECRET" }};
       proxy_hide_header          Access-Control-Allow-Origin;
 
       # Set headers on the response returned to the API client
@@ -61,7 +63,7 @@ http {
 
       # Hard code API version 1.1 because that's the only version which is
       # currently needed.
-      proxy_pass                 https://${API_DOMAIN}${API_PATH}/v1.1/$path$querystring;
+      proxy_pass                 https://{{env "API_FQDN"}}:{{env "API_PORT"}}/v1.1/$path$querystring;
     }
 
     # Proxy requests for the data route to the application's S3 bucket which
@@ -92,7 +94,7 @@ http {
       proxy_hide_header      Access-Control-Allow-Origin;
       add_header             Access-Control-Allow-Origin $allow_origin;
       add_header             Access-Control-Allow-Methods $allow_methods;
-      proxy_pass             ${S3_BUCKET_URL}/data/$url_full;
+      proxy_pass             {{env "S3_BUCKET_URL"}}/data/$url_full;
     }
 
     location / {


### PR DESCRIPTION
- Set network policy in deploy job to allow traffic to the API interal route
- Use NGINX buildpack properly to allow interpolation and DNS server population
- Convert api key to api data gov secret
