### PR TITLE
[BugFix] Video play CSV download links

### DIFF
--- a/js/components/data_downloads/DataDownloads.js
+++ b/js/components/data_downloads/DataDownloads.js
@@ -91,7 +91,7 @@ function DataDownloads({ dataURL, dataPrefix }) {
                   JSON
                 </a>
                 <a
-                  href={hrefBase + "/top-downloads-7-days.csv"}
+                  href={hrefBase + "/top-video-plays-7-days.csv"}
                   className="download-data usa-button"
                   aria-label="top-video-plays-7-days.csv"
                 >
@@ -196,7 +196,7 @@ function DataDownloads({ dataURL, dataPrefix }) {
                   JSON
                 </a>
                 <a
-                  href={hrefBase + "/top-downloads-30-days.csv"}
+                  href={hrefBase + "/top-video-plays-30-days.csv"}
                   className="download-data usa-button"
                   aria-label="top-video-plays-30-days.csv"
                 >

--- a/js/components/data_downloads/__tests__/__snapshots__/DataDownloads.spec.js.snap
+++ b/js/components/data_downloads/__tests__/__snapshots__/DataDownloads.spec.js.snap
@@ -115,7 +115,7 @@ exports[`DataDownloads renders 1`] = `
             <a
               aria-label="top-video-plays-7-days.csv"
               className="download-data usa-button"
-              href="http://www.example.com/foobar/top-downloads-7-days.csv"
+              href="http://www.example.com/foobar/top-video-plays-7-days.csv"
             >
               CSV
             </a>
@@ -250,7 +250,7 @@ exports[`DataDownloads renders 1`] = `
             <a
               aria-label="top-video-plays-30-days.csv"
               className="download-data usa-button"
-              href="http://www.example.com/foobar/top-downloads-30-days.csv"
+              href="http://www.example.com/foobar/top-video-plays-30-days.csv"
             >
               CSV
             </a>


### PR DESCRIPTION
- These links point to top downloads reports instead of video plays.  Fix the links

## Summary
Resolves Issue #

*Describe the pull request here, including any supplemental information needed to understand it.*

## Impacted Areas of the Site

## Optional Screenshots

## This pull request changes...
- [ ] 


## This pull request is ready to merge when...
- [ ] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
- [ ] The change has been documented

