### PR TITLE
Update the audit log review reminder Github action

### DIFF
--- a/.github/workflows/log_check_reminder.yml
+++ b/.github/workflows/log_check_reminder.yml
@@ -47,5 +47,4 @@ jobs:
             - [ ] **Cloud.gov**: Verify ssh disabled for production applications and spaces.
             - [ ] **Google Analytics**: Review the GA4 Account Change History (viewing instructions at https://support.google.com/analytics/answer/9305465?hl=en).
             - [ ] **AWS**: Review CloudTrail logs for AWS S3 and CloudFront.
-            - [ ] **GitHub**: Review Github Organization Audit Logs for all repos under the [analytics.usa.gov](https://github.com/orgs/18F/teams/analytics-usa-gov) team in the 18F organization.
             - [ ] **New Relic**: Review NrAuditEvent events for 'analytics.usa.gov' account.


### PR DESCRIPTION
Removing Github from the list of systems that must be checked manually in the audit log review. @JJediny told me that audit logs for all GitHub orgs have recently started to be streamed to the GSA SoC, which is convenient, because Github audit logs have been hard to access (only organizational owners may view audit logs). Now the SoC can be responsible for monitoring Github audit logs.
