### PR TITLE
[Bugfix] Handle spaces in download filenames and handle file locations with different domains from the event page

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,5 @@
+name: CI workflow
+
 on:
   push:
   pull_request:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,3 +1,5 @@
+name: Shared deploy job
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/manual_deploy_to_dev.yml
+++ b/.github/workflows/manual_deploy_to_dev.yml
@@ -1,3 +1,5 @@
+name: Manual deploy to dev
+
 on:
   workflow_dispatch:
 

--- a/ga4-data/live/top-downloads-30-days.json
+++ b/ga4-data/live/top-downloads-30-days.json
@@ -1,45 +1,50 @@
 {
   "name": "top-downloads-30-days",
+  "agency": null,
+  "sampling": [
+    {
+      "samplesReadCount": "98955525",
+      "samplingSpaceSize": "13321884079"
+    }
+  ],
   "query": {
-    "dimensions": [
-      {
-        "name": "pageTitle"
-      },
-      {
-        "name": "eventName"
-      },
-      {
-        "name": "fileName"
-      },
-      {
-        "name": "fullPageUrl"
-      }
-    ],
+    "limit": "100",
     "metrics": [
       {
         "name": "eventCount"
       }
     ],
-    "dateRanges": [
-      {
-        "startDate": "30daysAgo",
-        "endDate": "yesterday"
-      }
-    ],
     "orderBys": [
       {
+        "desc": true,
         "metric": {
           "metricName": "eventCount"
-        },
-        "desc": true
+        }
+      }
+    ],
+    "dateRanges": [
+      {
+        "endDate": "yesterday",
+        "startDate": "30daysAgo"
+      }
+    ],
+    "dimensions": [
+      {
+        "name": "pageTitle"
+      },
+      {
+        "name": "fullPageUrl"
+      },
+      {
+        "name": "linkUrl"
       }
     ],
     "dimensionFilter": {
       "filter": {
         "fieldName": "eventName",
         "stringFilter": {
-          "matchType": "FULL_REGEXP",
           "value": "^(file_download|download|downloads|(outbound downloads))$",
+          "matchType": "FULL_REGEXP",
           "caseSensitive": false
         }
       },
@@ -50,8 +55,8 @@
               "filter": {
                 "fieldName": "fileName",
                 "stringFilter": {
-                  "matchType": "PARTIAL_REGEXP",
                   "value": ".*\\\\.(zip|doc)\\b.*",
+                  "matchType": "PARTIAL_REGEXP",
                   "caseSensitive": false
                 }
               }
@@ -62,8 +67,8 @@
               "filter": {
                 "fieldName": "fullPageUrl",
                 "stringFilter": {
-                  "matchType": "PARTIAL_REGEXP",
                   "value": ".*\\busps\\.com\\b.*",
+                  "matchType": "PARTIAL_REGEXP",
                   "caseSensitive": false
                 }
               }
@@ -72,8 +77,7 @@
         ]
       }
     },
-    "limit": "100",
-    "property": "properties/393249053"
+    "property": "properties/397708109"
   },
   "meta": {
     "name": "Top Downloads (30 Days)",
@@ -81,706 +85,608 @@
   },
   "data": [
     {
-      "page_title": "Employment Eligibility Verification | USCIS",
-      "event_label": "file_download",
-      "file_name": "/sites/default/files/document/forms/i-9.pdf",
-      "page": "www.uscis.gov/i-9",
-      "total_events": "218941"
+      "page_title": "Diversity Visa Instructions",
+      "page": "travel.state.gov/content/travel/en/us-visas/immigrate/diversity-visa-program-entry/diversity-visa-instructions.html",
+      "linkUrl": "https://travel.state.gov/content/dam/visas/diversity-visa/dv-instructions-translations/dv-2026-instructions-translations/dv 2026 plain language instructions and faqs.pdf",
+      "total_events": "705031"
     },
     {
-      "page_title": "Replace Social Security card | SSA",
-      "event_label": "file_download",
-      "file_name": "/forms/ss-5.pdf",
-      "page": "www.ssa.gov/number-card/replace-card",
-      "total_events": "147782"
+      "page_title": "BrucePac Recalls Ready-To-Eat Meat and Poultry Products Due to Possible Listeria Contamination | Food Safety and Inspection Service",
+      "page": "www.fsis.usda.gov/recalls-alerts/brucepac-recalls-ready-eat-meat-and-poultry-products-due-possible-listeria",
+      "linkUrl": "https://www.fsis.usda.gov/sites/default/files/food_label_pdf/2024-10/recall-028-2024-labels.pdf",
+      "total_events": "384085"
     },
     {
-      "page_title": "About Form W-9, Request for Taxpayer Identification Number and Certification | Internal Revenue Service",
-      "event_label": "file_download",
-      "file_name": "/pub/irs-pdf/fw9.pdf",
-      "page": "www.irs.gov/forms-pubs/about-form-w-9",
-      "total_events": "141179"
-    },
-    {
-      "page_title": "Affidavit of Support Under Section 213A of the INA | USCIS",
-      "event_label": "file_download",
-      "file_name": "/sites/default/files/document/forms/i-864.pdf",
-      "page": "www.uscis.gov/i-864",
-      "total_events": "120685"
-    },
-    {
-      "page_title": "Fee Schedule | USCIS",
-      "event_label": "file_download",
-      "file_name": "/sites/default/files/document/forms/g-1055.pdf",
-      "page": "www.uscis.gov/g-1055",
-      "total_events": "110666"
-    },
-    {
-      "page_title": "Apply for your First Passport as an Adult",
-      "event_label": "file_download",
-      "file_name": "/forms/ds11.pdf",
-      "page": "travel.state.gov/content/travel/en/passports/need-passport/apply-in-person.html",
-      "total_events": "102468"
-    },
-    {
-      "page_title": "Renew my Passport by Mail",
-      "event_label": "file_download",
-      "file_name": "/forms/ds82.pdf",
-      "page": "travel.state.gov/content/travel/en/passports/have-passport/renew.html",
-      "total_events": "90058"
-    },
-    {
-      "page_title": "Application to Register Permanent Residence or Adjust Status | USCIS",
-      "event_label": "file_download",
-      "file_name": "/sites/default/files/document/forms/i-485.pdf",
-      "page": "www.uscis.gov/i-485",
-      "total_events": "89831"
-    },
-    {
-      "page_title": "About Form W-4, Employee's Withholding Certificate | Internal Revenue Service",
-      "event_label": "file_download",
-      "file_name": "/pub/irs-pdf/fw4.pdf",
-      "page": "www.irs.gov/forms-pubs/about-form-w-4",
-      "total_events": "88806"
-    },
-    {
-      "page_title": "Application for Employment Authorization | USCIS",
-      "event_label": "file_download",
-      "file_name": "/sites/default/files/document/forms/i-765.pdf",
-      "page": "www.uscis.gov/i-765",
-      "total_events": "85390"
-    },
-    {
-      "page_title": "Passport Forms",
-      "event_label": "file_download",
-      "file_name": "/forms/ds11_pdf.pdf",
-      "page": "travel.state.gov/content/travel/en/passports/how-apply/forms.html",
-      "total_events": "82430"
-    },
-    {
-      "page_title": "Apply for a Child's U.S. Passport",
-      "event_label": "file_download",
-      "file_name": "/forms/ds11_pdf.pdf",
-      "page": "travel.state.gov/content/travel/en/passports/need-passport/under-16.html",
-      "total_events": "79242"
-    },
-    {
-      "page_title": "Petition for Alien Relative | USCIS",
-      "event_label": "file_download",
-      "file_name": "/sites/default/files/document/forms/i-130.pdf",
-      "page": "www.uscis.gov/i-130",
-      "total_events": "78218"
-    },
-    {
-      "page_title": "Advancement",
-      "event_label": "file_download",
-      "file_name": "/portals/55/career/enlistedcareeradmin/advancement/cycle 263 actar quotas.pdf",
-      "page": "www.mynavyhr.navy.mil/career-management/community-management/enlisted-career-admin/advancement/",
-      "total_events": "69337"
-    },
-    {
-      "page_title": "Application for Naturalization | USCIS",
-      "event_label": "file_download",
-      "file_name": "/sites/default/files/document/forms/n-400.pdf",
-      "page": "www.uscis.gov/n-400",
-      "total_events": "65466"
-    },
-    {
-      "page_title": "About Form W-4V, Voluntary Withholding Request | Internal Revenue Service",
-      "event_label": "file_download",
-      "file_name": "/pub/irs-pdf/fw4v.pdf",
-      "page": "www.irs.gov/forms-pubs/about-form-w-4-v",
-      "total_events": "62164"
-    },
-    {
-      "page_title": "Change name with Social Security | SSA",
-      "event_label": "file_download",
-      "file_name": "/forms/ss-5.pdf",
-      "page": "www.ssa.gov/personal-record/change-name",
-      "total_events": "61823"
-    },
-    {
-      "page_title": "GOES-East - Continental U.S. (CONUS) - NOAA / NESDIS / STAR",
-      "event_label": "file_download",
-      "file_name": "/goes16/abi/conus/geocolor/[REDACTED_TEL]",
-      "page": "www.star.nesdis.noaa.gov/goes/conus.php",
-      "total_events": "57041"
-    },
-    {
-      "page_title": "Request for Fee Waiver | USCIS",
-      "event_label": "file_download",
-      "file_name": "/sites/default/files/document/forms/i-912.pdf",
-      "page": "www.uscis.gov/i-912",
-      "total_events": "55902"
-    },
-    {
-      "page_title": "Employment Eligibility Verification | USCIS",
-      "event_label": "file_download",
-      "file_name": "/sites/default/files/document/forms/i-9instr.pdf",
-      "page": "www.uscis.gov/i-9",
-      "total_events": "55447"
-    },
-    {
-      "page_title": "Replacement card | SSA",
-      "event_label": "file_download",
-      "file_name": "/forms/ss-5.pdf",
-      "page": "www.ssa.gov/number-card/replace-card/get-started/applicant",
-      "total_events": "54194"
-    },
-    {
-      "page_title": "General Schedule",
-      "event_label": "file_download",
-      "file_name": "/policy-data-oversight/pay-leave/salaries-wages/salary-tables/24tables/pdf/rus.pdf",
-      "page": "www.opm.gov/policy-data-oversight/pay-leave/salaries-wages/2024/general-schedule/",
-      "total_events": "50210"
-    },
-    {
-      "page_title": "Application for Asylum and for Withholding of Removal | USCIS",
-      "event_label": "file_download",
-      "file_name": "/sites/default/files/document/forms/i-589.pdf",
-      "page": "www.uscis.gov/i-589",
-      "total_events": "47022"
-    },
-    {
-      "page_title": "About Form 4506-T, Request for Transcript of Tax Return | Internal Revenue Service",
-      "event_label": "file_download",
-      "file_name": "/pub/irs-pdf/f4506t.pdf",
-      "page": "www.irs.gov/forms-pubs/about-form-4506-t",
-      "total_events": "46680"
-    },
-    {
-      "page_title": "About Form 1040, U.S. Individual Income Tax Return | Internal Revenue Service",
-      "event_label": "file_download",
-      "file_name": "/pub/irs-pdf/f1040.pdf",
-      "page": "www.irs.gov/forms-pubs/about-form-1040",
-      "total_events": "46111"
-    },
-    {
-      "page_title": "About Form W-2, Wage and Tax Statement | Internal Revenue Service",
-      "event_label": "file_download",
-      "file_name": "/pub/irs-pdf/fw2.pdf",
-      "page": "www.irs.gov/forms-pubs/about-form-w-2",
-      "total_events": "45655"
-    },
-    {
-      "page_title": "General Schedule",
-      "event_label": "file_download",
-      "file_name": "/policy-data-oversight/pay-leave/salaries-wages/salary-tables/24tables/pdf/dcb.pdf",
-      "page": "www.opm.gov/policy-data-oversight/pay-leave/salaries-wages/2024/general-schedule/",
-      "total_events": "45428"
-    },
-    {
-      "page_title": "Friendship Festival",
-      "event_label": "file_download",
-      "file_name": "/portals/44/ff 2024 event 20240514_1.pdf",
-      "page": "www.yokota.af.mil/friendship-festival/",
-      "total_events": "44517"
-    },
-    {
-      "page_title": "Small Entity Compliance Guide | FinCEN.gov",
-      "event_label": "file_download",
-      "file_name": "/sites/default/files/shared/boi_small_compliance_guide.v1.1-final.pdf",
-      "page": "www.fincen.gov/boi/small-entity-compliance-guide",
-      "total_events": "44175"
-    },
-    {
-      "page_title": "About Form 8822, Change of Address | Internal Revenue Service",
-      "event_label": "file_download",
-      "file_name": "/pub/irs-pdf/f8822.pdf",
-      "page": "www.irs.gov/forms-pubs/about-form-8822",
-      "total_events": "43378"
-    },
-    {
-      "page_title": "Notice of Entry of Appearance as Attorney or Accredited Representative | USCIS",
-      "event_label": "file_download",
-      "file_name": "/sites/default/files/document/forms/g-28.pdf",
-      "page": "www.uscis.gov/g-28",
-      "total_events": "43378"
-    },
-    {
-      "page_title": "Form MCS-150 and Instructions - Motor Carrier Identification Report | FMCSA",
-      "event_label": "file_download",
-      "file_name": "/sites/fmcsa.dot.gov/files/2024-04/mcs-150 form.pdf",
-      "page": "www.fmcsa.dot.gov/registration/form-mcs-150-and-instructions-motor-carrier-identification-report",
-      "total_events": "42695"
-    },
-    {
-      "page_title": "Alien’s Change of Address Card | USCIS",
-      "event_label": "file_download",
-      "file_name": "/sites/default/files/document/forms/ar-11.pdf",
-      "page": "www.uscis.gov/ar-11",
-      "total_events": "41784"
-    },
-    {
-      "page_title": "Application for Travel Document | USCIS",
-      "event_label": "file_download",
-      "file_name": "/sites/default/files/document/forms/i-131.pdf",
-      "page": "www.uscis.gov/i-131",
-      "total_events": "41557"
-    },
-    {
-      "page_title": "Army Publishing Directorate",
-      "event_label": "file_download",
-      "file_name": "/pub/eforms/dr_a/arn39139-da_form_4856-001-efile-2.pdf",
-      "page": "armypubs.army.mil/productmaps/pubform/details.aspx",
-      "total_events": "41329"
-    },
-    {
-      "page_title": "Passport Forms",
-      "event_label": "file_download",
-      "file_name": "/forms/ds82_pdf.pdf",
-      "page": "travel.state.gov/content/travel/en/passports/how-apply/forms.html",
-      "total_events": "39963"
-    },
-    {
-      "page_title": "Declaration of Financial Support | USCIS",
-      "event_label": "file_download",
-      "file_name": "/sites/default/files/document/forms/i-134.pdf",
-      "page": "www.uscis.gov/i-134",
-      "total_events": "39166"
-    },
-    {
-      "page_title": "Application to Replace Permanent Resident Card (Green Card) | USCIS",
-      "event_label": "file_download",
-      "file_name": "/sites/default/files/document/forms/i-90.pdf",
-      "page": "www.uscis.gov/i-90",
-      "total_events": "39052"
-    },
-    {
-      "page_title": "E-Notification of Application/Petition Acceptance | USCIS",
-      "event_label": "file_download",
-      "file_name": "/sites/default/files/document/forms/g-1145.pdf",
-      "page": "www.uscis.gov/g-1145",
-      "total_events": "39052"
-    },
-    {
-      "page_title": "Form 6059B Customs Declaration - English (Fillable) | U.S. Customs and Border Protection",
-      "event_label": "file_download",
-      "file_name": "/sites/default/files/assets/documents/2022-jun/cbp form 6059b_english.pdf",
-      "page": "www.cbp.gov/document/forms/form-6059b-customs-declaration-english-fillable",
-      "total_events": "38027"
-    },
-    {
-      "page_title": "Forms & Instructions | Internal Revenue Service",
-      "event_label": "file_download",
-      "file_name": "/pub/irs-pdf/f1040.pdf",
-      "page": "www.irs.gov/forms-instructions",
-      "total_events": "36206"
-    },
-    {
-      "page_title": "Apply for a Child's U.S. Passport",
-      "event_label": "file_download",
-      "file_name": "/forms/ds3053.pdf",
-      "page": "travel.state.gov/content/travel/en/passports/need-passport/under-16.html",
-      "total_events": "35978"
-    },
-    {
-      "page_title": "Friendship Festival",
-      "event_label": "file_download",
-      "file_name": "/portals/44/ff 2024 area map 20240516.pdf",
-      "page": "www.yokota.af.mil/friendship-festival/",
-      "total_events": "35978"
-    },
-    {
-      "page_title": "Health insurance plans & prices | HealthCare.gov",
-      "event_label": "file_download",
-      "file_name": "/2024/fl/sbc/2024_40572fl[REDACTED_SSN]",
-      "page": "www.healthcare.gov/see-plans/#/",
-      "total_events": "35409"
-    },
-    {
-      "page_title": "Application to Register Permanent Residence or Adjust Status | USCIS",
-      "event_label": "file_download",
-      "file_name": "/sites/default/files/document/forms/i-485instr.pdf",
-      "page": "www.uscis.gov/i-485",
-      "total_events": "34839"
-    },
-    {
-      "page_title": "FMLA: Forms | U.S. Department of Labor",
-      "event_label": "file_download",
-      "file_name": "/sites/dolgov/files/whd/legacy/files/wh-380-e.pdf",
-      "page": "www.dol.gov/agencies/whd/fmla/forms",
-      "total_events": "34839"
-    },
-    {
-      "page_title": "About Form 1040-X, Amended U.S. Individual Income Tax Return | Internal Revenue Service",
-      "event_label": "file_download",
-      "file_name": "/pub/irs-pdf/f1040x.pdf",
-      "page": "www.irs.gov/forms-pubs/about-form-1040x",
-      "total_events": "34725"
-    },
-    {
-      "page_title": "General Schedule",
-      "event_label": "file_download",
-      "file_name": "/policy-data-oversight/pay-leave/salaries-wages/salary-tables/24tables/pdf/rus.pdf",
-      "page": "www.opm.gov/policy-data-oversight/pay-leave/salaries-wages/2024/general-schedule",
-      "total_events": "34725"
-    },
-    {
-      "page_title": "Report of Immigration Medical Examination and Vaccination Record | USCIS",
-      "event_label": "file_download",
-      "file_name": "/sites/default/files/document/forms/i-693.pdf",
-      "page": "www.uscis.gov/i-693",
-      "total_events": "33587"
-    },
-    {
-      "page_title": "EmploymentEligibilityVerification|USCIS",
-      "event_label": "file_download",
-      "file_name": "/sites/default/files/document/forms/i-9.pdf",
-      "page": "www.uscis.gov/i-9",
-      "total_events": "33018"
-    },
-    {
-      "page_title": "Applicable Federal Rates | Internal Revenue Service",
-      "event_label": "file_download",
-      "file_name": "/pub/irs-drop/rr-24-09.pdf",
-      "page": "www.irs.gov/applicable-federal-rates",
-      "total_events": "32334"
-    },
-    {
-      "page_title": "DS-160: Frequently Asked Questions",
-      "event_label": "file_download",
-      "file_name": "/content/dam/visas/pdf-other/ds-160-example_[REDACTED_DOB]",
-      "page": "travel.state.gov/content/travel/en/us-visas/visa-information-resources/forms/ds-160-online-nonimmigrant-visa-application/ds-160-faqs.html#doclist",
-      "total_events": "31993"
-    },
-    {
-      "page_title": "Affidavit of Support Under Section 213A of the INA | USCIS",
-      "event_label": "file_download",
-      "file_name": "/sites/default/files/document/forms/i-864instr.pdf",
-      "page": "www.uscis.gov/i-864",
-      "total_events": "31538"
-    },
-    {
-      "page_title": "Friendship Festival",
-      "event_label": "file_download",
-      "file_name": "/portals/44/ff24 booth listing 20240516b.pdf",
-      "page": "www.yokota.af.mil/friendship-festival/",
-      "total_events": "31424"
-    },
-    {
-      "page_title": "About Form SS-4, Application for Employer Identification Number (EIN) | Internal Revenue Service",
-      "event_label": "file_download",
-      "file_name": "/pub/irs-pdf/fss4.pdf",
-      "page": "www.irs.gov/forms-pubs/about-form-ss-4",
-      "total_events": "31310"
-    },
-    {
-      "page_title": "Birth-18 Years Immunization Schedule – Healthcare Providers | CDC",
-      "event_label": "file_download",
-      "file_name": "/vaccines/schedules/downloads/child/0-18yrs-child-combined-schedule.pdf",
-      "page": "www.cdc.gov/vaccines/schedules/hcp/imz/child-adolescent.html",
-      "total_events": "31196"
-    },
-    {
-      "page_title": "ALEJANDRO ROSALES CASTILLO — FBI",
-      "event_label": "file_download",
-      "file_name": "/wanted/topten/alejandro-castillo/@@download.pdf",
-      "page": "www.fbi.gov/wanted/topten/alejandro-castillo",
-      "total_events": "31082"
-    },
-    {
-      "page_title": "About Form 843, Claim for Refund and Request for Abatement | Internal Revenue Service",
-      "event_label": "file_download",
-      "file_name": "/pub/irs-pdf/f843.pdf",
-      "page": "www.irs.gov/forms-pubs/about-form-843",
-      "total_events": "30513"
-    },
-    {
-      "page_title": "Joint Typhoon Warning Center (JTWC)",
-      "event_label": "file_download",
-      "file_name": "/jtwc/products/abpwweb.txt",
-      "page": "www.metoc.navy.mil/jtwc/jtwc.html",
-      "total_events": "30513"
-    },
-    {
-      "page_title": "Awards: President's Education Awards Program",
-      "event_label": "file_download",
-      "file_name": "https://www2.ed.gov/programs/presedaward/2024/peap-excellence.pdf",
-      "page": "www2.ed.gov/programs/presedaward/awards.html",
-      "total_events": "30399"
-    },
-    {
-      "page_title": "RUJA IGNATOVA — FBI",
-      "event_label": "file_download",
-      "file_name": "/wanted/topten/ruja-ignatova/@@download.pdf",
-      "page": "www.fbi.gov/wanted/topten/ruja-ignatova",
-      "total_events": "30399"
-    },
-    {
-      "page_title": "Study for the Test | USCIS",
-      "event_label": "file_download",
-      "file_name": "/sites/default/files/document/questions-and-answers/ooc_100_questions_2008_civics_test_v1.pdf",
-      "page": "www.uscis.gov/citizenship/find-study-materials-and-resources/study-for-the-test",
-      "total_events": "29602"
-    },
-    {
-      "page_title": "Application for Naturalization | USCIS",
-      "event_label": "file_download",
-      "file_name": "/sites/default/files/document/forms/n-400instr.pdf",
-      "page": "www.uscis.gov/n-400",
-      "total_events": "29260"
-    },
-    {
-      "page_title": "General Schedule",
-      "event_label": "file_download",
-      "file_name": "/policy-data-oversight/pay-leave/salaries-wages/salary-tables/24tables/pdf/dcb.pdf",
-      "page": "www.opm.gov/policy-data-oversight/pay-leave/salaries-wages/2024/general-schedule",
-      "total_events": "29033"
-    },
-    {
-      "page_title": "Authorization for Credit Card Transactions | USCIS",
-      "event_label": "file_download",
-      "file_name": "/sites/default/files/document/forms/g-1450.pdf",
-      "page": "www.uscis.gov/g-1450",
-      "total_events": "28805"
-    },
-    {
-      "page_title": "CMS 40B | CMS",
-      "event_label": "file_download",
-      "file_name": "/medicare/cms-forms/cms-forms/downloads/cms40b-e.pdf",
-      "page": "www.cms.gov/medicare/cms-forms/cms-forms/cms-forms-items/cms017339",
-      "total_events": "28805"
-    },
-    {
-      "page_title": "About Form W-7, Application for IRS Individual Taxpayer Identification Number | Internal Revenue Service",
-      "event_label": "file_download",
-      "file_name": "/pub/irs-pdf/fw7.pdf",
-      "page": "www.irs.gov/forms-pubs/about-form-w-7",
-      "total_events": "27894"
-    },
-    {
-      "page_title": "SAVE Tutorial | USCIS",
-      "event_label": "file_download",
-      "file_name": "/sites/default/files/document/guides/savetutorial.pdf",
-      "page": "www.uscis.gov/save/save-resources/save-tutorial",
-      "total_events": "27325"
-    },
-    {
-      "page_title": "Friendship Festival",
-      "event_label": "file_download",
-      "file_name": "/portals/44/ff 24 static display map 04240516(womv) .pdf",
-      "page": "www.yokota.af.mil/friendship-festival/",
-      "total_events": "27097"
-    },
-    {
-      "page_title": "VITEL'HOMME INNOCENT — FBI",
-      "event_label": "file_download",
-      "file_name": "/wanted/topten/vitelhomme-innocent/@@download.pdf",
-      "page": "www.fbi.gov/wanted/topten/vitelhomme-innocent",
-      "total_events": "26983"
-    },
-    {
-      "page_title": "Application for Employment Authorization | USCIS",
-      "event_label": "file_download",
-      "file_name": "/sites/default/files/document/forms/i-765instr.pdf",
-      "page": "www.uscis.gov/i-765",
-      "total_events": "26300"
-    },
-    {
-      "page_title": "AboutFormW-9,RequestforTaxpayerIdentificationNumberandCertification|InternalRevenueService",
-      "event_label": "file_download",
-      "file_name": "/pub/irs-pdf/fw9.pdf",
-      "page": "www.irs.gov/forms-pubs/about-form-w-9",
-      "total_events": "26186"
-    },
-    {
-      "page_title": "Petition for Alien Fiancé(e) | USCIS",
-      "event_label": "file_download",
-      "file_name": "/sites/default/files/document/forms/i-129f.pdf",
-      "page": "www.uscis.gov/i-129f",
-      "total_events": "25503"
-    },
-    {
-      "page_title": "Applicable Federal Rates | Internal Revenue Service",
-      "event_label": "file_download",
-      "file_name": "/pub/irs-drop/rr-24-12.pdf",
-      "page": "www.irs.gov/applicable-federal-rates",
-      "total_events": "25162"
-    },
-    {
-      "page_title": "Vaccine Information Statement | Tdap | Tetanus-Diphtheria-Pertussis | VIS | CDC",
-      "event_label": "file_download",
-      "file_name": "/vaccines/hcp/vis/vis-statements/tdap.pdf",
-      "page": "www.cdc.gov/vaccines/hcp/vis/vis-statements/tdap.html",
-      "total_events": "25162"
-    },
-    {
-      "page_title": "General Schedule",
-      "event_label": "file_download",
-      "file_name": "/policy-data-oversight/pay-leave/salaries-wages/salary-tables/24tables/pdf/gs.pdf",
-      "page": "www.opm.gov/policy-data-oversight/pay-leave/salaries-wages/2024/general-schedule/",
-      "total_events": "24934"
-    },
-    {
-      "page_title": "About Form 8822-B, Change of Address or Responsible Party - Business | Internal Revenue Service",
-      "event_label": "file_download",
-      "file_name": "/pub/irs-pdf/f8822b.pdf",
-      "page": "www.irs.gov/forms-pubs/about-form-8822-b",
-      "total_events": "24706"
-    },
-    {
-      "page_title": "Visa Bulletin For June 2024",
-      "event_label": "file_download",
-      "file_name": "/content/dam/visas/bulletins/visabulletin_june2024.pdf",
-      "page": "travel.state.gov/content/travel/en/legal/visa-law0/visa-bulletin/2024/visa-bulletin-for-june-2024.html",
-      "total_events": "24592"
-    },
-    {
-      "page_title": "General Schedule",
-      "event_label": "file_download",
-      "file_name": "/policy-data-oversight/pay-leave/salaries-wages/salary-tables/24tables/pdf/gs.pdf",
-      "page": "www.opm.gov/policy-data-oversight/pay-leave/salaries-wages/2024/general-schedule",
-      "total_events": "24251"
-    },
-    {
-      "page_title": "About Form 1040-ES, Estimated Tax for Individuals | Internal Revenue Service",
-      "event_label": "file_download",
-      "file_name": "/pub/irs-pdf/f1040es.pdf",
-      "page": "www.irs.gov/forms-pubs/about-form-1040-es",
-      "total_events": "24023"
-    },
-    {
-      "page_title": "National Hurricane Center",
-      "event_label": "file_download",
-      "file_name": "/pdf/nhc_cone_graphic_change_announcement.pdf",
-      "page": "www.nhc.noaa.gov/",
-      "total_events": "24023"
+      "page_title": "BOI E-FILING",
+      "page": "boiefiling.fincen.gov/",
+      "linkUrl": "https://boiefiling.fincen.gov/c8576e94532490750200.pdf",
+      "total_events": "305464"
     },
     {
       "page_title": "Diversity Visa Instructions",
-      "event_label": "file_download",
-      "file_name": "/content/dam/visas/diversity-visa/dv-instructions-translations/dv-2025-instructions-translations/dv-2025_instructions-faqs.pdf",
       "page": "travel.state.gov/content/travel/en/us-visas/immigrate/diversity-visa-program-entry/diversity-visa-instructions.html",
-      "total_events": "23909"
+      "linkUrl": "https://travel.state.gov/content/dam/visas/diversity-visa/dv-instructions-translations/dv-2025-instructions-translations/dv-2025-instructions.pdf",
+      "total_events": "299137"
     },
     {
-      "page_title": "Request Military Personnel Records Using Standard Form 180 | National Archives",
-      "event_label": "file_download",
-      "file_name": "/files/veterans/military-service-records/standard-form-180.pdf",
-      "page": "www.archives.gov/veterans/military-service-records/standard-form-180.html",
-      "total_events": "23795"
+      "page_title": "Employment Eligibility Verification | USCIS",
+      "page": "www.uscis.gov/i-9",
+      "linkUrl": "https://www.uscis.gov/sites/default/files/document/forms/i-9.pdf",
+      "total_events": "229939"
     },
     {
-      "page_title": "FMLA: Forms | U.S. Department of Labor",
-      "event_label": "file_download",
-      "file_name": "/sites/dolgov/files/whd/legacy/files/wh-380-f.pdf",
-      "page": "www.dol.gov/agencies/whd/fmla/forms",
-      "total_events": "23112"
-    },
-    {
-      "page_title": "ReplaceSocialSecuritycard|SSA",
-      "event_label": "file_download",
-      "file_name": "/forms/ss-5.pdf",
+      "page_title": "Replace Social Security card | SSA",
       "page": "www.ssa.gov/number-card/replace-card",
-      "total_events": "22885"
+      "linkUrl": "https://www.ssa.gov/forms/ss-5.pdf",
+      "total_events": "159396"
     },
     {
-      "page_title": "Beneficial Ownership Information Reporting | FinCEN.gov",
-      "event_label": "file_download",
-      "file_name": "/sites/default/files/shared/boi-informational-brochure-april-2024.pdf",
-      "page": "www.fincen.gov/boi",
-      "total_events": "22771"
+      "page_title": "About Form W-9, Request for Taxpayer Identification Number and Certification | Internal Revenue Service",
+      "page": "www.irs.gov/forms-pubs/about-form-w-9",
+      "linkUrl": "https://www.irs.gov/pub/irs-pdf/fw9.pdf",
+      "total_events": "156165"
     },
     {
-      "page_title": "BHADRESHKUMAR CHETANBHAI PATEL — FBI",
-      "event_label": "file_download",
-      "file_name": "/wanted/topten/bhadreshkumar-chetanbhai-patel/@@download.pdf",
-      "page": "www.fbi.gov/wanted/topten/bhadreshkumar-chetanbhai-patel",
-      "total_events": "22543"
+      "page_title": "Affidavit of Support Under Section 213A of the INA | USCIS",
+      "page": "www.uscis.gov/i-864",
+      "linkUrl": "https://www.uscis.gov/sites/default/files/document/forms/i-864.pdf",
+      "total_events": "142433"
     },
     {
-      "page_title": "I94 - Official Website",
-      "event_label": "file_download",
-      "file_name": "/i94/i94-en.pdf",
-      "page": "i94.cbp.dhs.gov/i94/#/home",
-      "total_events": "22429"
+      "page_title": "Application to Register Permanent Residence or Adjust Status | USCIS",
+      "page": "www.uscis.gov/i-485",
+      "linkUrl": "https://www.uscis.gov/sites/default/files/document/forms/i-485.pdf",
+      "total_events": "124932"
     },
     {
-      "page_title": "Payroll Calendars | GSA",
-      "event_label": "file_download",
-      "file_name": "/system/files/2024_gsa_payroll_calendar.pdf",
-      "page": "www.gsa.gov/buy-through-us/purchasing-programs/shared-services/payroll-shared-services/payroll-calendars",
-      "total_events": "22429"
+      "page_title": "Latest Satellite Imagery",
+      "page": "www.nhc.noaa.gov/satellite.php",
+      "linkUrl": "https://cdn.star.nesdis.noaa.gov/goes16/abi/sector/gm/geocolor/1000x1000.jpg",
+      "total_events": "122913"
     },
     {
-      "page_title": "About Form 2848, Power of Attorney and Declaration of Representative | Internal Revenue Service",
-      "event_label": "file_download",
-      "file_name": "/pub/irs-pdf/f2848.pdf",
-      "page": "www.irs.gov/forms-pubs/about-form-2848",
-      "total_events": "22201"
+      "page_title": "Diversity Visa Instructions",
+      "page": "travel.state.gov/content/travel/en/us-visas/immigrate/diversity-visa-program-entry/diversity-visa-instructions.html",
+      "linkUrl": "https://travel.state.gov/content/dam/visas/diversity-visa/dv-instructions-translations/dv-2026-instructions-translations/dv-2026 how_to_apply_infographic.pdf",
+      "total_events": "116047"
     },
     {
-      "page_title": "About Form W-8 BEN, Certificate of Foreign Status of Beneficial Owner for United States Tax Withholding and Reporting (Individuals) | Internal Revenue Service",
-      "event_label": "file_download",
-      "file_name": "/pub/irs-pdf/fw8ben.pdf",
-      "page": "www.irs.gov/forms-pubs/about-form-w-8-ben",
-      "total_events": "22201"
+      "page_title": "Small Entity Compliance Guide | FinCEN.gov",
+      "page": "www.fincen.gov/boi/small-entity-compliance-guide",
+      "linkUrl": "https://www.fincen.gov/sites/default/files/shared/boi_small_compliance_guide.v1.1-final.pdf",
+      "total_events": "105950"
     },
     {
-      "page_title": "Hepatitis B Vaccine Information Statement | CDC",
-      "event_label": "file_download",
-      "file_name": "/vaccines/hcp/vis/vis-statements/hep-b.pdf",
-      "page": "www.cdc.gov/vaccines/hcp/vis/vis-statements/hep-b.html",
-      "total_events": "21860"
+      "page_title": "Application for Employment Authorization | USCIS",
+      "page": "www.uscis.gov/i-765",
+      "linkUrl": "https://www.uscis.gov/sites/default/files/document/forms/i-765.pdf",
+      "total_events": "105815"
     },
     {
-      "page_title": "Visa Bulletin For May 2024",
-      "event_label": "file_download",
-      "file_name": "/content/dam/visas/bulletins/visabulletin_may2024.pdf",
-      "page": "travel.state.gov/content/travel/en/legal/visa-law0/visa-bulletin/2024/visa-bulletin-for-may-2024.html",
-      "total_events": "21291"
+      "page_title": "Fee Schedule | USCIS",
+      "page": "www.uscis.gov/g-1055",
+      "linkUrl": "https://www.uscis.gov/sites/default/files/document/forms/g-1055.pdf",
+      "total_events": "105142"
     },
     {
-      "page_title": "WASDE Report | USDA",
-      "event_label": "file_download",
-      "file_name": "/oce/commodity/wasde/wasde0524.pdf",
-      "page": "www.usda.gov/oce/commodity/wasde",
-      "total_events": "21177"
+      "page_title": "Inactivated Influenza Vaccine Information Statement | CDC",
+      "page": "www.cdc.gov/vaccines/hcp/vis/vis-statements/flu.html",
+      "linkUrl": "https://www.cdc.gov/vaccines/hcp/vis/vis-statements/flu.pdf",
+      "total_events": "98142"
     },
     {
-      "page_title": "Contract Between Sponsor and Household Member | USCIS",
-      "event_label": "file_download",
-      "file_name": "/sites/default/files/document/forms/i-864a.pdf",
-      "page": "www.uscis.gov/i-864a",
-      "total_events": "20949"
+      "page_title": "Passport Forms",
+      "page": "travel.state.gov/content/travel/en/passports/how-apply/forms.html",
+      "linkUrl": "https://eforms.state.gov/forms/ds11_pdf.pdf",
+      "total_events": "88179"
+    },
+    {
+      "page_title": "Change name with Social Security | SSA",
+      "page": "www.ssa.gov/personal-record/change-name",
+      "linkUrl": "https://www.ssa.gov/forms/ss-5.pdf",
+      "total_events": "88045"
+    },
+    {
+      "page_title": "About Form W-4, Employee's Withholding Certificate | Internal Revenue Service",
+      "page": "www.irs.gov/forms-pubs/about-form-w-4",
+      "linkUrl": "https://www.irs.gov/pub/irs-pdf/fw4.pdf",
+      "total_events": "82794"
     },
     {
       "page_title": "Petition for Alien Relative | USCIS",
-      "event_label": "file_download",
-      "file_name": "/sites/default/files/document/forms/i-130instr.pdf",
       "page": "www.uscis.gov/i-130",
-      "total_events": "20835"
+      "linkUrl": "https://www.uscis.gov/sites/default/files/document/forms/i-130.pdf",
+      "total_events": "77275"
     },
     {
-      "page_title": "Form I-94 Arrival/Departure Record | U.S. Customs and Border Protection",
-      "event_label": "file_download",
-      "file_name": "/sites/default/files/documents/cbp form i-94 english sample_watermark.pdf",
-      "page": "www.cbp.gov/document/forms/form-i-94-arrivaldeparture-record",
-      "total_events": "20721"
+      "page_title": "Application for Naturalization | USCIS",
+      "page": "www.uscis.gov/n-400",
+      "linkUrl": "https://www.uscis.gov/sites/default/files/document/forms/n-400.pdf",
+      "total_events": "72967"
     },
     {
       "page_title": "Request for Fee Waiver | USCIS",
-      "event_label": "file_download",
-      "file_name": "/sites/default/files/document/forms/i-912instr.pdf",
       "page": "www.uscis.gov/i-912",
-      "total_events": "20608"
+      "linkUrl": "https://www.uscis.gov/sites/default/files/document/forms/i-912.pdf",
+      "total_events": "72967"
     },
     {
-      "page_title": "Vaccine Schedule for Children 6 Years or Younger | CDC",
-      "event_label": "file_download",
-      "file_name": "/vaccines/parents/downloads/parent-ver-sch-0-6yrs.pdf",
-      "page": "www.cdc.gov/vaccines/schedules/easy-to-read/child-easyread.html",
-      "total_events": "20608"
+      "page_title": "About Form 1040, U.S. Individual Income Tax Return | Internal Revenue Service",
+      "page": "www.irs.gov/forms-pubs/about-form-1040",
+      "linkUrl": "https://www.irs.gov/pub/irs-pdf/f1040.pdf",
+      "total_events": "71351"
     },
     {
-      "page_title": "DS-260 Immigrant Visa Electronic Application - Frequently Asked Questions (FAQs)",
-      "event_label": "file_download",
-      "file_name": "/content/dam/visas/ds-260-exemplar.pdf",
-      "page": "travel.state.gov/content/travel/en/us-visas/visa-information-resources/forms/online-immigrant-visa-forms/ds-260-faqs.html",
-      "total_events": "20494"
+      "page_title": "Latest Satellite Imagery",
+      "page": "www.nhc.noaa.gov/satellite.php",
+      "linkUrl": "https://cdn.star.nesdis.noaa.gov/goes16/abi/sector/gm/13/1000x1000.jpg",
+      "total_events": "68389"
+    },
+    {
+      "page_title": "BrucePac Recalls Ready-To-Eat Meat and Poultry Products Due to Possible Listeria Contamination | Food Safety and Inspection Service",
+      "page": "www.fsis.usda.gov/recalls-alerts/brucepac-recalls-ready-eat-meat-and-poultry-products-due-possible-listeria",
+      "linkUrl": "https://www.fsis.usda.gov/sites/default/files/distro_list/2024-10/rc-028-2024-retail-list.pdf",
+      "total_events": "67043"
+    },
+    {
+      "page_title": "Find out if you are eligible for the Diversity Visa (DV) Lottery and how to register | USAGov",
+      "page": "www.usa.gov/dv-lottery-eligibility",
+      "linkUrl": "https://travel.state.gov/content/dam/visas/diversity-visa/dv-instructions-translations/dv-2026-instructions-translations/dv 2026 plain language instructions and faqs.pdf",
+      "total_events": "61793"
+    },
+    {
+      "page_title": "Latest Satellite Imagery",
+      "page": "www.nhc.noaa.gov/satellite.php",
+      "linkUrl": "https://cdn.star.nesdis.noaa.gov/goes16/abi/sector/taw/geocolor/1800x1080.jpg",
+      "total_events": "60581"
+    },
+    {
+      "page_title": "BOI E-FILING",
+      "page": "boiefiling.fincen.gov/fileboir",
+      "linkUrl": "https://boiefiling.fincen.gov/c8576e94532490750200.pdf",
+      "total_events": "59639"
+    },
+    {
+      "page_title": "Application for Asylum and for Withholding of Removal | USCIS",
+      "page": "www.uscis.gov/i-589",
+      "linkUrl": "https://www.uscis.gov/sites/default/files/document/forms/i-589.pdf",
+      "total_events": "56946"
+    },
+    {
+      "page_title": "Latest Satellite Imagery",
+      "page": "www.nhc.noaa.gov/satellite.php",
+      "linkUrl": "https://cdn.star.nesdis.noaa.gov/goes16/abi/sector/gm/02/1000x1000.jpg",
+      "total_events": "56273"
+    },
+    {
+      "page_title": "Employment Eligibility Verification | USCIS",
+      "page": "www.uscis.gov/i-9",
+      "linkUrl": "https://www.uscis.gov/sites/default/files/document/forms/i-9instr.pdf",
+      "total_events": "55465"
+    },
+    {
+      "page_title": "E-Notification of Application/Petition Acceptance | USCIS",
+      "page": "www.uscis.gov/g-1145",
+      "linkUrl": "https://www.uscis.gov/sites/default/files/document/forms/g-1145.pdf",
+      "total_events": "55196"
+    },
+    {
+      "page_title": "About Form W-2, Wage and Tax Statement | Internal Revenue Service",
+      "page": "www.irs.gov/forms-pubs/about-form-w-2",
+      "linkUrl": "https://www.irs.gov/pub/irs-pdf/fw2.pdf",
+      "total_events": "55062"
+    },
+    {
+      "page_title": "General Schedule",
+      "page": "www.opm.gov/policy-data-oversight/pay-leave/salaries-wages/2024/general-schedule/",
+      "linkUrl": "https://www.opm.gov/policy-data-oversight/pay-leave/salaries-wages/salary-tables/24tables/pdf/dcb.pdf",
+      "total_events": "54792"
+    },
+    {
+      "page_title": "Replacement card | SSA",
+      "page": "www.ssa.gov/number-card/replace-card/get-started/applicant",
+      "linkUrl": "https://www.ssa.gov/forms/ss-5.pdf",
+      "total_events": "54658"
+    },
+    {
+      "page_title": "About Form 941, Employer's Quarterly Federal Tax Return | Internal Revenue Service",
+      "page": "www.irs.gov/forms-pubs/about-form-941",
+      "linkUrl": "https://www.irs.gov/pub/irs-pdf/f941.pdf",
+      "total_events": "53311"
+    },
+    {
+      "page_title": "Search the Physician Fee Schedule | CMS",
+      "page": "www.cms.gov/medicare/physician-fee-schedule/search",
+      "linkUrl": "https://www.cms.gov/files/document/physician-fee-schedule-guide.pdf",
+      "total_events": "52234"
+    },
+    {
+      "page_title": "Report of Immigration Medical Examination and Vaccination Record | USCIS",
+      "page": "www.uscis.gov/i-693",
+      "linkUrl": "https://www.uscis.gov/sites/default/files/document/forms/i-693.pdf",
+      "total_events": "51561"
+    },
+    {
+      "page_title": "Welcome to the Health Insurance Marketplace® | HealthCare.gov",
+      "page": "www.healthcare.gov/",
+      "linkUrl": "https://www.healthcare.gov/downloads/apply-for-or-renew-coverage.pdf",
+      "total_events": "50754"
+    },
+    {
+      "page_title": "Application to Register Permanent Residence or Adjust Status | USCIS",
+      "page": "www.uscis.gov/i-485",
+      "linkUrl": "https://www.uscis.gov/sites/default/files/document/forms/i-485instr.pdf",
+      "total_events": "50619"
+    },
+    {
+      "page_title": "About Form W-8 IMY, Certificate of Foreign Intermediary, Foreign Flow-Through Entity, or Certain U.S. Branches for United States Tax Withholding and Reporting | Internal Revenue Service",
+      "page": "www.irs.gov/forms-pubs/about-form-w-8-imy",
+      "linkUrl": "https://www.irs.gov/pub/irs-pdf/fw8imy.pdf",
+      "total_events": "49542"
+    },
+    {
+      "page_title": "Forms & instructions | Internal Revenue Service",
+      "page": "www.irs.gov/forms-instructions",
+      "linkUrl": "https://www.irs.gov/pub/irs-pdf/f1040.pdf",
+      "total_events": "49003"
+    },
+    {
+      "page_title": "Alien’s Change of Address Card | USCIS",
+      "page": "www.uscis.gov/ar-11",
+      "linkUrl": "https://www.uscis.gov/sites/default/files/document/forms/ar-11.pdf",
+      "total_events": "48061"
+    },
+    {
+      "page_title": "Applicable Federal Rates | Internal Revenue Service",
+      "page": "www.irs.gov/applicable-federal-rates",
+      "linkUrl": "https://www.irs.gov/pub/irs-drop/rr-24-21.pdf",
+      "total_events": "47657"
+    },
+    {
+      "page_title": "About Form 4506-T, Request for Transcript of Tax Return | Internal Revenue Service",
+      "page": "www.irs.gov/forms-pubs/about-form-4506-t",
+      "linkUrl": "https://www.irs.gov/pub/irs-pdf/f4506t.pdf",
+      "total_events": "46715"
+    },
+    {
+      "page_title": "Premiums",
+      "page": "www.opm.gov/healthcare-insurance/healthcare/plan-information/premiums/",
+      "linkUrl": "https://www.opm.gov/healthcare-insurance/healthcare/plan-information/premiums/2025/fehb/2025-fehb-ffs-premium-rates.xlsx",
+      "total_events": "46715"
+    },
+    {
+      "page_title": "About Form 8822, Change of Address | Internal Revenue Service",
+      "page": "www.irs.gov/forms-pubs/about-form-8822",
+      "linkUrl": "https://www.irs.gov/pub/irs-pdf/f8822.pdf",
+      "total_events": "45369"
+    },
+    {
+      "page_title": "Application to Replace Permanent Resident Card (Green Card) | USCIS",
+      "page": "www.uscis.gov/i-90",
+      "linkUrl": "https://www.uscis.gov/sites/default/files/document/forms/i-90.pdf",
+      "total_events": "44830"
+    },
+    {
+      "page_title": "General Schedule",
+      "page": "www.opm.gov/policy-data-oversight/pay-leave/salaries-wages/2024/general-schedule/",
+      "linkUrl": "https://www.opm.gov/policy-data-oversight/pay-leave/salaries-wages/salary-tables/24tables/pdf/rus.pdf",
+      "total_events": "44561"
+    },
+    {
+      "page_title": "Build A Kit | Ready.gov",
+      "page": "www.ready.gov/kit",
+      "linkUrl": "https://www.ready.gov/sites/default/files/2024-05/ready_supply-kit-checklist.pdf",
+      "total_events": "44022"
+    },
+    {
+      "page_title": "Army Publishing Directorate",
+      "page": "armypubs.army.mil/productmaps/pubform/details.aspx",
+      "linkUrl": "https://armypubs.army.mil/pub/eforms/dr_a/arn39139-da_form_4856-001-efile-2.pdf",
+      "total_events": "43753"
+    },
+    {
+      "page_title": "Medicare & You | Medicare",
+      "page": "www.medicare.gov/medicare-and-you",
+      "linkUrl": "https://www.medicare.gov/publications/10050-medicare-and-you.pdf",
+      "total_events": "43349"
+    },
+    {
+      "page_title": "Notice of Entry of Appearance as Attorney or Accredited Representative | USCIS",
+      "page": "www.uscis.gov/g-28",
+      "linkUrl": "https://www.uscis.gov/sites/default/files/document/forms/g-28.pdf",
+      "total_events": "42811"
+    },
+    {
+      "page_title": "Forms & instructions | Internal Revenue Service",
+      "page": "www.irs.gov/forms-instructions",
+      "linkUrl": "https://www.irs.gov/pub/irs-pdf/i1040gi.pdf",
+      "total_events": "42138"
+    },
+    {
+      "page_title": "“Lotería de visas”: averigüe si es elegible y cómo participar | USAGov",
+      "page": "www.usa.gov/es/participar-loteria-visas",
+      "linkUrl": "https://travel.state.gov/content/dam/visas/diversity-visa/dv-instructions-translations/dv-2026-instructions-translations/dv 2026 plain language instructions and faqs.pdf",
+      "total_events": "42003"
+    },
+    {
+      "page_title": "Diversity Visa Instructions",
+      "page": "travel.state.gov/content/travel/en/us-visas/immigrate/diversity-visa-program-entry/diversity-visa-instructions.html",
+      "linkUrl": "https://travel.state.gov/content/dam/visas/diversity-visa/dv-instructions-translations/dv-2026-instructions-translations/dv_2026_instructions_ukr.pdf",
+      "total_events": "41868"
+    },
+    {
+      "page_title": "CMS 40B | CMS",
+      "page": "www.cms.gov/medicare/cms-forms/cms-forms/cms-forms-items/cms017339",
+      "linkUrl": "https://www.cms.gov/medicare/cms-forms/cms-forms/downloads/cms40b-e.pdf",
+      "total_events": "41599"
+    },
+    {
+      "page_title": "Premiums",
+      "page": "www.opm.gov/healthcare-insurance/healthcare/plan-information/premiums/",
+      "linkUrl": "https://www.opm.gov/healthcare-insurance/healthcare/plan-information/premiums/2025/fehb/2025-fehb-hmo-premium-rates.xlsx",
+      "total_events": "41599"
+    },
+    {
+      "page_title": "About Form W-4V, Voluntary Withholding Request | Internal Revenue Service",
+      "page": "www.irs.gov/forms-pubs/about-form-w-4-v",
+      "linkUrl": "https://www.irs.gov/pub/irs-pdf/fw4v.pdf",
+      "total_events": "41195"
+    },
+    {
+      "page_title": "Latest Satellite Imagery",
+      "page": "www.nhc.noaa.gov/satellite.php",
+      "linkUrl": "https://cdn.star.nesdis.noaa.gov/goes16/abi/conus/geocolor/1250x750.jpg",
+      "total_events": "39984"
+    },
+    {
+      "page_title": "BOI E-FILING",
+      "page": "boiefiling.fincen.gov/",
+      "linkUrl": "https://boiefiling.fincen.gov/resources/boir_filing_instructions.pdf",
+      "total_events": "38099"
+    },
+    {
+      "page_title": "Latest Satellite Imagery",
+      "page": "www.nhc.noaa.gov/satellite.php",
+      "linkUrl": "https://cdn.star.nesdis.noaa.gov/goes16/abi/sector/gm/08/1000x1000.jpg",
+      "total_events": "38099"
+    },
+    {
+      "page_title": "General Schedule",
+      "page": "www.opm.gov/policy-data-oversight/pay-leave/salaries-wages/2024/general-schedule",
+      "linkUrl": "https://www.opm.gov/policy-data-oversight/pay-leave/salaries-wages/salary-tables/24tables/pdf/rus.pdf",
+      "total_events": "37560"
+    },
+    {
+      "page_title": "ASP Pricing Files | CMS",
+      "page": "www.cms.gov/medicare/payment/part-b-drugs/asp-pricing-files",
+      "linkUrl": "https://www.cms.gov/files/zip/october-2024-asp-pricing-file.zip",
+      "total_events": "36618"
+    },
+    {
+      "page_title": "Apply for your First Passport as an Adult",
+      "page": "travel.state.gov/content/travel/en/passports/need-passport/apply-in-person.html",
+      "linkUrl": "https://eforms.state.gov/forms/ds11.pdf",
+      "total_events": "36618"
+    },
+    {
+      "page_title": "General Schedule",
+      "page": "www.opm.gov/policy-data-oversight/pay-leave/salaries-wages/2024/general-schedule",
+      "linkUrl": "https://www.opm.gov/policy-data-oversight/pay-leave/salaries-wages/salary-tables/24tables/pdf/gs.pdf",
+      "total_events": "36483"
+    },
+    {
+      "page_title": "Form MCS-150 and Instructions - Motor Carrier Identification Report | FMCSA",
+      "page": "www.fmcsa.dot.gov/registration/form-mcs-150-and-instructions-motor-carrier-identification-report",
+      "linkUrl": "https://www.fmcsa.dot.gov/sites/fmcsa.dot.gov/files/2024-04/mcs-150 form.pdf",
+      "total_events": "36214"
+    },
+    {
+      "page_title": "General Schedule",
+      "page": "www.opm.gov/policy-data-oversight/pay-leave/salaries-wages/2024/general-schedule/",
+      "linkUrl": "https://www.opm.gov/policy-data-oversight/pay-leave/salaries-wages/salary-tables/24tables/pdf/gs.pdf",
+      "total_events": "36079"
+    },
+    {
+      "page_title": "Green Card | USCIS",
+      "page": "www.uscis.gov/green-card",
+      "linkUrl": "https://www.uscis.gov/sites/default/files/document/guides/greencard_comparison_en.pdf.pdf",
+      "total_events": "35810"
+    },
+    {
+      "page_title": "Latest Satellite Imagery",
+      "page": "www.nhc.noaa.gov/satellite.php",
+      "linkUrl": "https://cdn.star.nesdis.noaa.gov/goes16/abi/sector/gm/07/1000x1000.jpg",
+      "total_events": "35810"
+    },
+    {
+      "page_title": "About Schedule C (Form 1040), Profit or Loss from Business (Sole Proprietorship) | Internal Revenue Service",
+      "page": "www.irs.gov/forms-pubs/about-schedule-c-form-1040",
+      "linkUrl": "https://www.irs.gov/pub/irs-pdf/f1040sc.pdf",
+      "total_events": "35137"
+    },
+    {
+      "page_title": "Military Compensation > Pay > Basic Pay > Active Duty Pay",
+      "page": "militarypay.defense.gov/pay/basic-pay/active-duty-pay/",
+      "linkUrl": "https://militarypay.defense.gov/portals/3/documents/activedutytables/2024 pay table-capped-final.pdf",
+      "total_events": "35137"
+    },
+    {
+      "page_title": "Apply for a Child's U.S. Passport",
+      "page": "travel.state.gov/content/travel/en/passports/need-passport/under-16.html",
+      "linkUrl": "https://eforms.state.gov/forms/ds3053.pdf",
+      "total_events": "34868"
+    },
+    {
+      "page_title": "FMLA: Forms | U.S. Department of Labor",
+      "page": "www.dol.gov/agencies/whd/fmla/forms",
+      "linkUrl": "https://www.dol.gov/sites/dolgov/files/whd/legacy/files/wh-380-e.pdf",
+      "total_events": "34733"
+    },
+    {
+      "page_title": "Authorization for Credit Card Transactions | USCIS",
+      "page": "www.uscis.gov/g-1450",
+      "linkUrl": "https://www.uscis.gov/sites/default/files/document/forms/g-1450.pdf",
+      "total_events": "34464"
+    },
+    {
+      "page_title": "General Schedule",
+      "page": "www.opm.gov/policy-data-oversight/pay-leave/salaries-wages/2024/general-schedule",
+      "linkUrl": "https://www.opm.gov/policy-data-oversight/pay-leave/salaries-wages/salary-tables/24tables/pdf/dcb.pdf",
+      "total_events": "33925"
+    },
+    {
+      "page_title": "Application for Travel Documents, Parole Documents, and Arrival/Departure Records | USCIS",
+      "page": "www.uscis.gov/i-131",
+      "linkUrl": "https://www.uscis.gov/sites/default/files/document/forms/i-131.pdf",
+      "total_events": "33656"
+    },
+    {
+      "page_title": "Beneficial Ownership Information Reporting | FinCEN.gov",
+      "page": "www.fincen.gov/boi",
+      "linkUrl": "https://www.fincen.gov/sites/default/files/shared/boi-informational-brochure-april-2024.pdf",
+      "total_events": "32983"
+    },
+    {
+      "page_title": "About Form 1040-ES, Estimated Tax for Individuals | Internal Revenue Service",
+      "page": "www.irs.gov/forms-pubs/about-form-1040-es",
+      "linkUrl": "https://www.irs.gov/pub/irs-pdf/f1040es.pdf",
+      "total_events": "32714"
+    },
+    {
+      "page_title": "About Form 1099-MISC, Miscellaneous Information | Internal Revenue Service",
+      "page": "www.irs.gov/forms-pubs/about-form-1099-misc",
+      "linkUrl": "https://www.irs.gov/pub/irs-pdf/f1099msc.pdf",
+      "total_events": "32714"
+    },
+    {
+      "page_title": "Application for Employment Authorization | USCIS",
+      "page": "www.uscis.gov/i-765",
+      "linkUrl": "https://www.uscis.gov/sites/default/files/document/forms/i-765instr.pdf",
+      "total_events": "32445"
+    },
+    {
+      "page_title": "BrucePac Recalls Ready-To-Eat Meat and Poultry Products Due to Possible Listeria Contamination | Food Safety and Inspection Service",
+      "page": "www.fsis.usda.gov/recalls-alerts/brucepac-recalls-ready-eat-meat-and-poultry-products-due-possible-listeria",
+      "linkUrl": "https://www.fsis.usda.gov/sites/default/files/distro_list/2024-10/rc-028-2024-school_distribution_list.pdf",
+      "total_events": "32445"
+    },
+    {
+      "page_title": "Premiums",
+      "page": "www.opm.gov/healthcare-insurance/healthcare/plan-information/premiums/",
+      "linkUrl": "https://www.opm.gov/healthcare-insurance/healthcare/plan-information/premiums/2025/fehb/2025-spo-vs-sf-fehb.xlsx",
+      "total_events": "32445"
+    },
+    {
+      "page_title": "ALEJANDRO ROSALES CASTILLO — FBI",
+      "page": "www.fbi.gov/wanted/topten/alejandro-castillo",
+      "linkUrl": "https://www.fbi.gov/wanted/topten/alejandro-castillo/@@download.pdf",
+      "total_events": "32310"
+    },
+    {
+      "page_title": "Army Publishing Directorate",
+      "page": "armypubs.army.mil/productmaps/pubform/details.aspx",
+      "linkUrl": "https://armypubs.army.mil/pub/eforms/dr_a/arn34523-da_form_5960-000-efile-1.pdf",
+      "total_events": "32310"
+    },
+    {
+      "page_title": "About Form W-7, Application for IRS Individual Taxpayer Identification Number | Internal Revenue Service",
+      "page": "www.irs.gov/forms-pubs/about-form-w-7",
+      "linkUrl": "https://www.irs.gov/pub/irs-pdf/fw7.pdf",
+      "total_events": "32175"
+    },
+    {
+      "page_title": "Affidavit of Support Under Section 213A of the INA | USCIS",
+      "page": "www.uscis.gov/i-864",
+      "linkUrl": "https://www.uscis.gov/sites/default/files/document/forms/i-864instr.pdf",
+      "total_events": "32041"
+    },
+    {
+      "page_title": "Visa Bulletin For October 2024",
+      "page": "travel.state.gov/content/travel/en/legal/visa-law0/visa-bulletin/2025/visa-bulletin-for-october-2024.html",
+      "linkUrl": "https://travel.state.gov/content/dam/visas/bulletins/visabulletin_october2024.pdf",
+      "total_events": "32041"
+    },
+    {
+      "page_title": "Premiums",
+      "page": "www.opm.gov/healthcare-insurance/healthcare/plan-information/premiums/",
+      "linkUrl": "https://www.opm.gov/healthcare-insurance/healthcare/plan-information/premiums/2025/pshb/2025-pshb-ffs-premium-rates.xlsx",
+      "total_events": "31906"
+    },
+    {
+      "page_title": "Veterans Day Teachers Resource Guide - U.S. Department of Veterans Affairs",
+      "page": "department.va.gov/veterans-day/veterans-day-teachers-resource-guide/",
+      "linkUrl": "https://department.va.gov/wp-content/uploads/2024/08/2024_veteransdayteachersguide.pdf",
+      "total_events": "31906"
+    },
+    {
+      "page_title": "About Form SS-4, Application for Employer Identification Number (EIN) | Internal Revenue Service",
+      "page": "www.irs.gov/forms-pubs/about-form-ss-4",
+      "linkUrl": "https://www.irs.gov/pub/irs-pdf/fss4.pdf",
+      "total_events": "31771"
+    },
+    {
+      "page_title": "Federal Student Aid",
+      "page": "studentaid.gov/announcements-events/save-court-actions",
+      "linkUrl": "https://studentaid.gov/sites/default/files/incomedrivenrepayment-en-us.pdf",
+      "total_events": "31637"
+    },
+    {
+      "page_title": "Diversity Visa Instructions",
+      "page": "travel.state.gov/content/travel/en/us-visas/immigrate/diversity-visa-program-entry/diversity-visa-instructions.html",
+      "linkUrl": "https://travel.state.gov/content/dam/visas/diversity-visa/dv-instructions-translations/dv-2026-instructions-translations/dv-2026 instructions_turkish.pdf",
+      "total_events": "30964"
+    },
+    {
+      "page_title": "Housing Handbooks | HUD.gov / U.S. Department of Housing and Urban Development (HUD)",
+      "page": "www.hud.gov/program_offices/administration/hudclips/handbooks/hsgh",
+      "linkUrl": "https://www.hud.gov/sites/dfiles/ochco/documents/40001-hsgh-update15-052024.pdf",
+      "total_events": "30964"
+    },
+    {
+      "page_title": "Latest Satellite Imagery",
+      "page": "www.nhc.noaa.gov/satellite.php",
+      "linkUrl": "https://cdn.star.nesdis.noaa.gov/goes16/abi/sector/taw/13/1800x1080.jpg",
+      "total_events": "30964"
+    },
+    {
+      "page_title": "About Schedule A (Form 1040), Itemized Deductions | Internal Revenue Service",
+      "page": "www.irs.gov/forms-pubs/about-schedule-a-form-1040",
+      "linkUrl": "https://www.irs.gov/pub/irs-pdf/f1040sa.pdf",
+      "total_events": "30829"
+    },
+    {
+      "page_title": "About Form 8822-B, Change of Address or Responsible Party - Business | Internal Revenue Service",
+      "page": "www.irs.gov/forms-pubs/about-form-8822-b",
+      "linkUrl": "https://www.irs.gov/pub/irs-pdf/f8822b.pdf",
+      "total_events": "30560"
+    },
+    {
+      "page_title": "Confirm Your Qualifications",
+      "page": "travel.state.gov/content/travel/en/us-visas/immigrate/diversity-visa-program-entry/diversity-visa-if-you-are-selected/diversity-visa-confirm-your-qualifications.html",
+      "linkUrl": "https://travel.state.gov/content/dam/visas/diversity-visa/dv-instructions-translations/dv-2025-instructions-translations/dv-2025_instructions_accessible 7.8.2024.pdf",
+      "total_events": "29887"
+    },
+    {
+      "page_title": "Site Index Search | Internal Revenue Service",
+      "page": "www.irs.gov/site-index-search?query=941",
+      "linkUrl": "https://www.irs.gov/pub/irs-pdf/f941.pdf",
+      "total_events": "29887"
+    },
+    {
+      "page_title": "Petition to Remove Conditions on Residence | USCIS",
+      "page": "www.uscis.gov/i-751",
+      "linkUrl": "https://www.uscis.gov/sites/default/files/document/forms/i-751.pdf",
+      "total_events": "29617"
+    },
+    {
+      "page_title": "Declaration of Financial Support | USCIS",
+      "page": "www.uscis.gov/i-134",
+      "linkUrl": "https://www.uscis.gov/sites/default/files/document/forms/i-134.pdf",
+      "total_events": "28944"
     }
   ],
-  "totals": {},
-  "taken_at": "2024-05-30T10:01:34.540Z"
+  "totals": {
+    "total_events": 6931028
+  },
+  "taken_at": "2024-10-22T19:07:29.611Z"
 }

--- a/ga4-data/live/top-downloads-7-days.json
+++ b/ga4-data/live/top-downloads-7-days.json
@@ -1,42 +1,50 @@
 {
   "name": "top-downloads-7-days",
+  "agency": null,
+  "sampling": [
+    {
+      "samplesReadCount": "99373058",
+      "samplingSpaceSize": "2957028502"
+    }
+  ],
   "query": {
-    "dimensions": [
-      {
-        "name": "pageTitle"
-      },
-      {
-        "name": "eventName"
-      },
-      {
-        "name": "fullPageUrl"
-      }
-    ],
+    "limit": "100",
     "metrics": [
       {
         "name": "eventCount"
       }
     ],
-    "dateRanges": [
-      {
-        "startDate": "7daysAgo",
-        "endDate": "yesterday"
-      }
-    ],
     "orderBys": [
       {
+        "desc": true,
         "metric": {
           "metricName": "eventCount"
-        },
-        "desc": true
+        }
+      }
+    ],
+    "dateRanges": [
+      {
+        "endDate": "yesterday",
+        "startDate": "7daysAgo"
+      }
+    ],
+    "dimensions": [
+      {
+        "name": "pageTitle"
+      },
+      {
+        "name": "fullPageUrl"
+      },
+      {
+        "name": "linkUrl"
       }
     ],
     "dimensionFilter": {
       "filter": {
         "fieldName": "eventName",
         "stringFilter": {
-          "matchType": "FULL_REGEXP",
           "value": "^(file_download|download|downloads|(outbound downloads))$",
+          "matchType": "FULL_REGEXP",
           "caseSensitive": false
         }
       },
@@ -45,22 +53,10 @@
           {
             "notExpression": {
               "filter": {
-                "fieldName": "eventName",
-                "stringFilter": {
-                  "matchType": "PARTIAL_REGEXP",
-                  "value": "~swf$",
-                  "caseSensitive": false
-                }
-              }
-            }
-          },
-          {
-            "notExpression": {
-              "filter": {
                 "fieldName": "fileName",
                 "stringFilter": {
-                  "matchType": "PARTIAL_REGEXP",
                   "value": ".*\\\\.(zip|doc)\\b.*",
+                  "matchType": "PARTIAL_REGEXP",
                   "caseSensitive": false
                 }
               }
@@ -71,8 +67,8 @@
               "filter": {
                 "fieldName": "fullPageUrl",
                 "stringFilter": {
-                  "matchType": "PARTIAL_REGEXP",
                   "value": ".*\\busps\\.com\\b.*",
+                  "matchType": "PARTIAL_REGEXP",
                   "caseSensitive": false
                 }
               }
@@ -81,616 +77,616 @@
         ]
       }
     },
-    "limit": "100",
-    "samplingLevel": "HIGHER_PRECISION",
-    "property": "properties/393249053"
+    "property": "properties/397708109"
   },
   "meta": {
     "name": "Top Downloads (7 Days)",
-    "description": "Top downloads in the last 7 days."
+    "description": "Top 100 downloads in the last 7 days."
   },
   "data": [
     {
-      "page_title": "General Schedule",
-      "event_label": "file_download",
-      "page": "www.opm.gov/policy-data-oversight/pay-leave/salaries-wages/2024/general-schedule",
-      "total_events": "383015"
+      "page_title": "BrucePac Recalls Ready-To-Eat Meat and Poultry Products Due to Possible Listeria Contamination | Food Safety and Inspection Service",
+      "page": "www.fsis.usda.gov/recalls-alerts/brucepac-recalls-ready-eat-meat-and-poultry-products-due-possible-listeria",
+      "linkUrl": "https://www.fsis.usda.gov/sites/default/files/food_label_pdf/2024-10/recall-028-2024-labels.pdf",
+      "total_events": "296527"
     },
     {
-      "page_title": "Health insurance plans & prices | HealthCare.gov",
-      "event_label": "file_download",
-      "page": "www.healthcare.gov/see-plans/#/",
-      "total_events": "205056"
+      "page_title": "Diversity Visa Instructions",
+      "page": "travel.state.gov/content/travel/en/us-visas/immigrate/diversity-visa-program-entry/diversity-visa-instructions.html",
+      "linkUrl": "https://travel.state.gov/content/dam/visas/diversity-visa/dv-instructions-translations/dv-2026-instructions-translations/dv 2026 plain language instructions and faqs.pdf",
+      "total_events": "122122"
     },
     {
-      "page_title": "About Form W-9, Request for Taxpayer Identification Number and Certification | Internal Revenue Service",
-      "event_label": "file_download",
-      "page": "www.irs.gov/forms-pubs/about-form-w-9",
-      "total_events": "136164"
+      "page_title": "Diversity Visa Instructions",
+      "page": "travel.state.gov/content/travel/en/us-visas/immigrate/diversity-visa-program-entry/diversity-visa-instructions.html",
+      "linkUrl": "https://travel.state.gov/content/dam/visas/diversity-visa/dv-instructions-translations/dv-2025-instructions-translations/dv-2025-instructions.pdf",
+      "total_events": "120991"
     },
     {
-      "page_title": "Forms & Instructions | Internal Revenue Service",
-      "event_label": "file_download",
-      "page": "www.irs.gov/forms-instructions",
-      "total_events": "118391"
+      "page_title": "BOI E-FILING",
+      "page": "boiefiling.fincen.gov/",
+      "linkUrl": "https://boiefiling.fincen.gov/c8576e94532490750200.pdf",
+      "total_events": "75701"
     },
     {
-      "page_title": "Forms, Instructions and Publications | Internal Revenue Service",
-      "event_label": "file_download",
-      "page": "www.irs.gov/forms-instructions-and-publications",
-      "total_events": "103888"
-    },
-    {
-      "page_title": "Army Publishing Directorate",
-      "event_label": "file_download",
-      "page": "armypubs.army.mil/ProductMaps/PubForm/Details.aspx",
-      "total_events": "77794"
-    },
-    {
-      "page_title": "Drugs@FDA: FDA-Approved Drugs",
-      "event_label": "file_download",
-      "page": "www.accessdata.fda.gov/scripts/cder/daf/index.cfm",
-      "total_events": "68778"
+      "page_title": "BrucePac Recalls Ready-To-Eat Meat and Poultry Products Due to Possible Listeria Contamination | Food Safety and Inspection Service",
+      "page": "www.fsis.usda.gov/recalls-alerts/brucepac-recalls-ready-eat-meat-and-poultry-products-due-possible-listeria",
+      "linkUrl": "https://www.fsis.usda.gov/sites/default/files/distro_list/2024-10/rc-028-2024-retail-list.pdf",
+      "total_events": "61835"
     },
     {
       "page_title": "Employment Eligibility Verification | USCIS",
-      "event_label": "file_download",
       "page": "www.uscis.gov/i-9",
-      "total_events": "65169"
-    },
-    {
-      "page_title": "Passport Fees",
-      "event_label": "file_download",
-      "page": "travel.state.gov/content/travel/en/passports/how-apply/fees.html",
-      "total_events": "60847"
-    },
-    {
-      "page_title": "Prior Year Forms and Instructions | Internal Revenue Service",
-      "event_label": "file_download",
-      "page": "www.irs.gov/prior-year-forms-and-instructions",
-      "total_events": "60782"
-    },
-    {
-      "page_title": "General Schedule",
-      "event_label": "file_download",
-      "page": "www.opm.gov/policy-data-oversight/pay-leave/salaries-wages/2023/general-schedule/",
-      "total_events": "54955"
-    },
-    {
-      "page_title": "Planes médicos y precios | CuidadoDeSalud.gov",
-      "event_label": "file_download",
-      "page": "www.cuidadodesalud.gov/es/see-plans/#/",
-      "total_events": "51491"
-    },
-    {
-      "page_title": "Small Entity Compliance Guide | FinCEN.gov",
-      "event_label": "file_download",
-      "page": "www.fincen.gov/boi/small-entity-compliance-guide",
-      "total_events": "48350"
-    },
-    {
-      "page_title": "FMLA: Forms | U.S. Department of Labor",
-      "event_label": "file_download",
-      "page": "www.dol.gov/agencies/whd/fmla/forms",
-      "total_events": "46570"
-    },
-    {
-      "page_title": "About Form 1040, U.S. Individual Income Tax Return | Internal Revenue Service",
-      "event_label": "file_download",
-      "page": "www.irs.gov/forms-pubs/about-form-1040",
-      "total_events": "42798"
-    },
-    {
-      "page_title": "Social Security Forms | Social Security Administration",
-      "event_label": "file_download",
-      "page": "www.ssa.gov/forms/",
-      "total_events": "34915"
-    },
-    {
-      "page_title": "About Form W-4, Employee's Withholding Certificate | Internal Revenue Service",
-      "event_label": "file_download",
-      "page": "www.irs.gov/forms-pubs/about-form-w-4",
-      "total_events": "34770"
-    },
-    {
-      "page_title": "Tax Withholding | Internal Revenue Service",
-      "event_label": "file_download",
-      "page": "www.irs.gov/payments/tax-withholding",
-      "total_events": "33604"
-    },
-    {
-      "page_title": "Affidavit of Support Under Section 213A of the INA | USCIS",
-      "event_label": "file_download",
-      "page": "www.uscis.gov/i-864",
-      "total_events": "33475"
+      "linkUrl": "https://www.uscis.gov/sites/default/files/document/forms/i-9.pdf",
+      "total_events": "51152"
     },
     {
       "page_title": "Replace Social Security card | SSA",
-      "event_label": "file_download",
       "page": "www.ssa.gov/number-card/replace-card",
-      "total_events": "33313"
+      "linkUrl": "https://www.ssa.gov/forms/ss-5.pdf",
+      "total_events": "38684"
     },
     {
-      "page_title": "Apply for a Child's U.S. Passport",
-      "event_label": "file_download",
-      "page": "travel.state.gov/content/travel/en/passports/need-passport/under-16.html",
-      "total_events": "30690"
+      "page_title": "About Form W-9, Request for Taxpayer Identification Number and Certification | Internal Revenue Service",
+      "page": "www.irs.gov/forms-pubs/about-form-w-9",
+      "linkUrl": "https://www.irs.gov/pub/irs-pdf/fw9.pdf",
+      "total_events": "36571"
     },
     {
-      "page_title": "Feeder and Replacement Cattle Auctions | Agricultural Marketing Service",
-      "event_label": "file_download",
-      "page": "www.ams.usda.gov/market-news/feeder-and-replacement-cattle-auctions",
-      "total_events": "29201"
+      "page_title": "Affidavit of Support Under Section 213A of the INA | USCIS",
+      "page": "www.uscis.gov/i-864",
+      "linkUrl": "https://www.uscis.gov/sites/default/files/document/forms/i-864.pdf",
+      "total_events": "31929"
     },
     {
-      "page_title": "Application to Register Permanent Residence or Adjust Status | USCIS",
-      "event_label": "file_download",
-      "page": "www.uscis.gov/i-485",
-      "total_events": "28910"
-    },
-    {
-      "page_title": "Renew my Passport by Mail",
-      "event_label": "file_download",
-      "page": "travel.state.gov/content/travel/en/passports/have-passport/renew.html",
-      "total_events": "28052"
-    },
-    {
-      "page_title": "Applicable Federal Rates | Internal Revenue Service",
-      "event_label": "file_download",
-      "page": "www.irs.gov/applicable-federal-rates",
-      "total_events": "27550"
-    },
-    {
-      "page_title": "General Schedule",
-      "event_label": "file_download",
-      "page": "www.opm.gov/policy-data-oversight/pay-leave/salaries-wages/2023/general-schedule",
-      "total_events": "26967"
-    },
-    {
-      "page_title": "How to Apply in Person for a Passport",
-      "event_label": "file_download",
-      "page": "travel.state.gov/content/travel/en/passports/need-passport/apply-in-person.html",
-      "total_events": "26725"
-    },
-    {
-      "page_title": "Application for Employment Authorization | USCIS",
-      "event_label": "file_download",
-      "page": "www.uscis.gov/i-765",
-      "total_events": "26482"
-    },
-    {
-      "page_title": "About Form W-2, Wage and Tax Statement | Internal Revenue Service",
-      "event_label": "file_download",
-      "page": "www.irs.gov/forms-pubs/about-form-w-2",
-      "total_events": "25689"
-    },
-    {
-      "page_title": "Beneficial Ownership Information Reporting | FinCEN.gov",
-      "event_label": "file_download",
-      "page": "www.fincen.gov/boi",
-      "total_events": "25025"
-    },
-    {
-      "page_title": "About Form 1099-NEC, Nonemployee Compensation | Internal Revenue Service",
-      "event_label": "file_download",
-      "page": "www.irs.gov/forms-pubs/about-form-1099-nec",
-      "total_events": "24928"
-    },
-    {
-      "page_title": "Petition for Alien Relative | USCIS",
-      "event_label": "file_download",
-      "page": "www.uscis.gov/i-130",
-      "total_events": "24556"
-    },
-    {
-      "page_title": "Forms and Pubs Index Search | Internal Revenue Service",
-      "event_label": "file_download",
-      "page": "www.irs.gov/forms-pubs-search?query=1040",
-      "total_events": "23066"
-    },
-    {
-      "page_title": "Law Enforcement Officer",
-      "event_label": "file_download",
-      "page": "www.opm.gov/policy-data-oversight/pay-leave/salaries-wages/2024/law-enforcement-officer",
-      "total_events": "22435"
-    },
-    {
-      "page_title": "General Schedule",
-      "event_label": "file_download",
-      "page": "www.opm.gov/policy-data-oversight/pay-leave/salaries-wages/2024/general-schedule/",
-      "total_events": "22306"
-    },
-    {
-      "page_title": "GOES-East - Continental U.S. (CONUS) - NOAA / NESDIS / STAR",
-      "event_label": "file_download",
-      "page": "www.star.nesdis.noaa.gov/GOES/conus.php",
-      "total_events": "21804"
-    },
-    {
-      "page_title": "Passport Forms",
-      "event_label": "file_download",
-      "page": "travel.state.gov/content/travel/en/passports/how-apply/forms.html",
-      "total_events": "21205"
-    },
-    {
-      "page_title": "About Form 1099-MISC, Miscellaneous Information | Internal Revenue Service",
-      "event_label": "file_download",
-      "page": "www.irs.gov/forms-pubs/about-form-1099-misc",
-      "total_events": "20655"
-    },
-    {
-      "page_title": "About Form W-4V, Voluntary Withholding Request | Internal Revenue Service",
-      "event_label": "file_download",
-      "page": "www.irs.gov/forms-pubs/about-form-w-4-v",
-      "total_events": "20557"
-    },
-    {
-      "page_title": "Recordkeeping - Recordkeeping Forms | Occupational Safety and Health Administration",
-      "event_label": "file_download",
-      "page": "www.osha.gov/recordkeeping/forms",
-      "total_events": "19505"
-    },
-    {
-      "page_title": "Payroll Calendars | GSA",
-      "event_label": "file_download",
-      "page": "www.gsa.gov/buy-through-us/purchasing-programs/shared-services/payroll-shared-services/payroll-calendars",
-      "total_events": "18534"
-    },
-    {
-      "page_title": "Boston/Norton, MA Weather Forecast Office Winter Weather Forecasts",
-      "event_label": "file_download",
-      "page": "www.weather.gov/box/winter",
-      "total_events": "18502"
-    },
-    {
-      "page_title": "Application for Naturalization | USCIS",
-      "event_label": "file_download",
-      "page": "www.uscis.gov/n-400",
-      "total_events": "18324"
-    },
-    {
-      "page_title": "About Form 1040-ES, Estimated Tax for Individuals | Internal Revenue Service",
-      "event_label": "file_download",
-      "page": "www.irs.gov/forms-pubs/about-form-1040-es",
-      "total_events": "18081"
-    },
-    {
-      "page_title": "510(k) Premarket Notification",
-      "event_label": "file_download",
-      "page": "www.accessdata.fda.gov/scripts/cdrh/cfdocs/cfpmn/pmn.cfm",
-      "total_events": "17984"
-    },
-    {
-      "page_title": "Change name with Social Security | SSA",
-      "event_label": "file_download",
-      "page": "www.ssa.gov/personal-record/change-name",
-      "total_events": "17029"
-    },
-    {
-      "page_title": "About Form 941, Employer's Quarterly Federal Tax Return | Internal Revenue Service",
-      "event_label": "file_download",
-      "page": "www.irs.gov/forms-pubs/about-form-941",
-      "total_events": "15879"
-    },
-    {
-      "page_title": "Replacement Card",
-      "event_label": "file_download",
-      "page": "www.ssa.gov/number-card/replace-card/get-started/applicant",
-      "total_events": "15200"
-    },
-    {
-      "page_title": "SDO | Solar Dynamics Observatory",
-      "event_label": "file_download",
-      "page": "sdo.gsfc.nasa.gov/data/",
-      "total_events": "15054"
-    },
-    {
-      "page_title": "Application for Travel Document | USCIS",
-      "event_label": "file_download",
-      "page": "www.uscis.gov/i-131",
-      "total_events": "14908"
-    },
-    {
-      "page_title": "Application to Replace Permanent Resident Card (Green Card) | USCIS",
-      "event_label": "file_download",
-      "page": "www.uscis.gov/i-90",
-      "total_events": "14180"
-    },
-    {
-      "page_title": "I94 - Official Website",
-      "event_label": "file_download",
-      "page": "i94.cbp.dhs.gov/I94/#/home",
-      "total_events": "14180"
-    },
-    {
-      "page_title": "Astronomy Picture of the Day",
-      "event_label": "file_download",
-      "page": "apod.nasa.gov/apod/astropix.html",
-      "total_events": "14066"
-    },
-    {
-      "page_title": "About Schedule A (Form 1040), Itemized Deductions | Internal Revenue Service",
-      "event_label": "file_download",
-      "page": "www.irs.gov/forms-pubs/about-schedule-a-form-1040",
-      "total_events": "13581"
-    },
-    {
-      "page_title": "100 Civics Questions and Answers for the 2008 Test with MP3 Audio (English version) | USCIS",
-      "event_label": "file_download",
-      "page": "www.uscis.gov/citizenship/find-study-materials-and-resources/study-for-the-test/100-civics-questions-and-answers-with-mp3-audio-english-version",
-      "total_events": "13500"
-    },
-    {
-      "page_title": "Disability Benefits | SSA",
-      "event_label": "file_download",
-      "page": "www.ssa.gov/benefits/disability/",
-      "total_events": "13241"
-    },
-    {
-      "page_title": "Schedule of Social Security Payments | SSA",
-      "event_label": "file_download",
-      "page": "www.ssa.gov/pubs/calendar.htm",
-      "total_events": "13079"
-    },
-    {
-      "page_title": "Apply Online for Disability Benefits",
-      "event_label": "file_download",
-      "page": "www.ssa.gov/applyfordisability/",
-      "total_events": "12885"
-    },
-    {
-      "page_title": "Study for the Test | USCIS",
-      "event_label": "file_download",
-      "page": "www.uscis.gov/citizenship/find-study-materials-and-resources/study-for-the-test",
-      "total_events": "12771"
+      "page_title": "BrucePac Recalls Ready-To-Eat Meat and Poultry Products Due to Possible Listeria Contamination | Food Safety and Inspection Service",
+      "page": "www.fsis.usda.gov/recalls-alerts/brucepac-recalls-ready-eat-meat-and-poultry-products-due-possible-listeria",
+      "linkUrl": "https://www.fsis.usda.gov/sites/default/files/distro_list/2024-10/rc-028-2024-school_distribution_list.pdf",
+      "total_events": "31751"
     },
     {
       "page_title": "Request for Fee Waiver | USCIS",
-      "event_label": "file_download",
       "page": "www.uscis.gov/i-912",
-      "total_events": "12173"
+      "linkUrl": "https://www.uscis.gov/sites/default/files/document/forms/i-912.pdf",
+      "total_events": "29310"
     },
     {
-      "page_title": "Publications | SSA",
-      "event_label": "file_download",
-      "page": "www.ssa.gov/pubs/",
-      "total_events": "12140"
+      "page_title": "Application to Register Permanent Residence or Adjust Status | USCIS",
+      "page": "www.uscis.gov/i-485",
+      "linkUrl": "https://www.uscis.gov/sites/default/files/document/forms/i-485.pdf",
+      "total_events": "28953"
     },
     {
-      "page_title": "NAVADMIN 2023",
-      "event_label": "file_download",
-      "page": "www.mynavyhr.navy.mil/References/Messages/NAVADMIN-2023/",
-      "total_events": "12092"
+      "page_title": "Small Entity Compliance Guide | FinCEN.gov",
+      "page": "www.fincen.gov/boi/small-entity-compliance-guide",
+      "linkUrl": "https://www.fincen.gov/sites/default/files/shared/boi_small_compliance_guide.v1.1-final.pdf",
+      "total_events": "25859"
     },
     {
-      "page_title": "Title 38 Pay Schedules - Office of the Chief Human Capital Officer (OCHCO)",
-      "event_label": "file_download",
-      "page": "www.va.gov/OHRM/Pay/",
-      "total_events": "12011"
+      "page_title": "Fee Schedule | USCIS",
+      "page": "www.uscis.gov/g-1055",
+      "linkUrl": "https://www.uscis.gov/sites/default/files/document/forms/g-1055.pdf",
+      "total_events": "24668"
     },
     {
-      "page_title": "Forms for patent applications | USPTO",
-      "event_label": "file_download",
-      "page": "www.uspto.gov/patents/apply/forms",
-      "total_events": "11962"
+      "page_title": "Application for Employment Authorization | USCIS",
+      "page": "www.uscis.gov/i-765",
+      "linkUrl": "https://www.uscis.gov/sites/default/files/document/forms/i-765.pdf",
+      "total_events": "24579"
     },
     {
-      "page_title": "Prior Year Forms and Instructions | Internal Revenue Service",
-      "event_label": "file_download",
-      "page": "www.irs.gov/forms-pubs/prior-year",
-      "total_events": "11865"
+      "page_title": "Passport Forms",
+      "page": "travel.state.gov/content/travel/en/passports/how-apply/forms.html",
+      "linkUrl": "https://eforms.state.gov/forms/ds11_pdf.pdf",
+      "total_events": "23597"
     },
     {
-      "page_title": "Latest Satellite Imagery",
-      "event_label": "file_download",
-      "page": "www.nhc.noaa.gov/satellite.php",
-      "total_events": "11816"
+      "page_title": "Change name with Social Security | SSA",
+      "page": "www.ssa.gov/personal-record/change-name",
+      "linkUrl": "https://www.ssa.gov/forms/ss-5.pdf",
+      "total_events": "21187"
     },
     {
-      "page_title": "Declaration of Financial Support | USCIS",
-      "event_label": "file_download",
-      "page": "www.uscis.gov/i-134",
-      "total_events": "11752"
+      "page_title": "Inactivated Influenza Vaccine Information Statement | CDC",
+      "page": "www.cdc.gov/vaccines/hcp/vis/vis-statements/flu.html",
+      "linkUrl": "https://www.cdc.gov/vaccines/hcp/vis/vis-statements/flu.pdf",
+      "total_events": "20830"
     },
     {
-      "page_title": "MUTCD 11th Edition - FHWA MUTCD",
-      "event_label": "file_download",
-      "page": "mutcd.fhwa.dot.gov/kno_11th_Edition.htm",
-      "total_events": "11736"
+      "page_title": "Petition for Alien Relative | USCIS",
+      "page": "www.uscis.gov/i-130",
+      "linkUrl": "https://www.uscis.gov/sites/default/files/document/forms/i-130.pdf",
+      "total_events": "20711"
     },
     {
-      "page_title": "About Form 940, Employer's Annual Federal Unemployment (FUTA) Tax Return | Internal Revenue Service",
-      "event_label": "file_download",
-      "page": "www.irs.gov/forms-pubs/about-form-940",
-      "total_events": "11719"
+      "page_title": "Diversity Visa Instructions",
+      "page": "travel.state.gov/content/travel/en/us-visas/immigrate/diversity-visa-program-entry/diversity-visa-instructions.html",
+      "linkUrl": "https://travel.state.gov/content/dam/visas/diversity-visa/dv-instructions-translations/dv-2026-instructions-translations/dv-2026 how_to_apply_infographic.pdf",
+      "total_events": "20086"
     },
     {
-      "page_title": "2024 NASA Science Planning Guide - NASA Science",
-      "event_label": "file_download",
-      "page": "science.nasa.gov/multimedia-galleries/2024-nasa-science-planning-guide/",
-      "total_events": "11638"
+      "page_title": "Application for Travel Documents, Parole Documents, and Arrival/Departure Records | USCIS",
+      "page": "www.uscis.gov/i-131",
+      "linkUrl": "https://www.uscis.gov/sites/default/files/document/forms/i-131.pdf",
+      "total_events": "18271"
     },
     {
-      "page_title": "Find A VA Form | Veterans Affairs",
-      "event_label": "file_download",
-      "page": "www.va.gov/find-forms/",
-      "total_events": "11525"
+      "page_title": "About Form W-4, Employee's Withholding Certificate | Internal Revenue Service",
+      "page": "www.irs.gov/forms-pubs/about-form-w-4",
+      "linkUrl": "https://www.irs.gov/pub/irs-pdf/fw4.pdf",
+      "total_events": "18092"
     },
     {
-      "page_title": "Travis AFB Passenger Terminal",
-      "event_label": "file_download",
-      "page": "www.amc.af.mil/AMC-Travel-Site/Terminals/CONUS-Terminals/Travis-AFB-Passenger-Terminal/",
-      "total_events": "11525"
+      "page_title": "About Form 1040, U.S. Individual Income Tax Return | Internal Revenue Service",
+      "page": "www.irs.gov/forms-pubs/about-form-1040",
+      "linkUrl": "https://www.irs.gov/pub/irs-pdf/f1040.pdf",
+      "total_events": "17140"
     },
     {
-      "page_title": "Federal Pell Grants | Federal Student Aid",
-      "event_label": "file_download",
-      "page": "studentaid.gov/understand-aid/types/grants/pell",
-      "total_events": "11509"
+      "page_title": "BOI E-FILING",
+      "page": "boiefiling.fincen.gov/fileboir",
+      "linkUrl": "https://boiefiling.fincen.gov/c8576e94532490750200.pdf",
+      "total_events": "16604"
     },
     {
-      "page_title": "Report of Immigration Medical Examination and Vaccination Record | USCIS",
-      "event_label": "file_download",
-      "page": "www.uscis.gov/i-693",
-      "total_events": "11412"
+      "page_title": "Application for Naturalization | USCIS",
+      "page": "www.uscis.gov/n-400",
+      "linkUrl": "https://www.uscis.gov/sites/default/files/document/forms/n-400.pdf",
+      "total_events": "15116"
     },
     {
-      "page_title": "ASP Pricing Files | CMS",
-      "event_label": "file_download",
-      "page": "www.cms.gov/medicare/payment/all-fee-service-providers/medicare-part-b-drug-average-sales-price/asp-pricing-files",
-      "total_events": "11282"
+      "page_title": "About Form W-2, Wage and Tax Statement | Internal Revenue Service",
+      "page": "www.irs.gov/forms-pubs/about-form-w-2",
+      "linkUrl": "https://www.irs.gov/pub/irs-pdf/fw2.pdf",
+      "total_events": "14849"
     },
     {
-      "page_title": "Valley Meats, LLC, Recalls Ground Beef Products Due to Possible E. Coli O157:H7 Contamination | Food Safety and Inspection Service",
-      "event_label": "file_download",
-      "page": "www.fsis.usda.gov/recalls-alerts/valley-meats-llc-recalls-ground-beef-products-due-possible-e--coli-o157h7",
-      "total_events": "11185"
+      "page_title": "Welcome to the Health Insurance Marketplace® | HealthCare.gov",
+      "page": "www.healthcare.gov/",
+      "linkUrl": "https://www.healthcare.gov/downloads/apply-for-or-renew-coverage.pdf",
+      "total_events": "14730"
     },
     {
-      "page_title": "About Schedule C (Form 1040), Profit or Loss from Business (Sole Proprietorship) | Internal Revenue Service",
-      "event_label": "file_download",
-      "page": "www.irs.gov/forms-pubs/about-schedule-c-form-1040",
-      "total_events": "11169"
+      "page_title": "About Form 941, Employer's Quarterly Federal Tax Return | Internal Revenue Service",
+      "page": "www.irs.gov/forms-pubs/about-form-941",
+      "linkUrl": "https://www.irs.gov/pub/irs-pdf/f941.pdf",
+      "total_events": "13837"
     },
     {
-      "page_title": "Cost-of-Living Adjustment (COLA) Information | SSA",
-      "event_label": "file_download",
-      "page": "www.ssa.gov/cola/",
-      "total_events": "10959"
+      "page_title": "General Schedule",
+      "page": "www.opm.gov/policy-data-oversight/pay-leave/salaries-wages/2024/general-schedule/",
+      "linkUrl": "https://www.opm.gov/policy-data-oversight/pay-leave/salaries-wages/salary-tables/24tables/pdf/dcb.pdf",
+      "total_events": "13182"
     },
     {
-      "page_title": "About Form 5695, Residential Energy Credits | Internal Revenue Service",
-      "event_label": "file_download",
-      "page": "www.irs.gov/forms-pubs/about-form-5695",
-      "total_events": "10894"
+      "page_title": "Find out if you are eligible for the Diversity Visa (DV) Lottery and how to register | USAGov",
+      "page": "www.usa.gov/dv-lottery-eligibility",
+      "linkUrl": "https://travel.state.gov/content/dam/visas/diversity-visa/dv-instructions-translations/dv-2026-instructions-translations/dv 2026 plain language instructions and faqs.pdf",
+      "total_events": "13063"
     },
     {
-      "page_title": "Petition to Remove Conditions on Residence | USCIS",
-      "event_label": "file_download",
-      "page": "www.uscis.gov/i-751",
-      "total_events": "10861"
+      "page_title": "Replacement card | SSA",
+      "page": "www.ssa.gov/number-card/replace-card/get-started/applicant",
+      "linkUrl": "https://www.ssa.gov/forms/ss-5.pdf",
+      "total_events": "12974"
     },
     {
-      "page_title": "Site Index Search | Internal Revenue Service",
-      "event_label": "file_download",
-      "page": "www.irs.gov/site-index-search?query=1040",
-      "total_events": "10748"
-    },
-    {
-      "page_title": "Title 38 Pay Schedules - Office of the Chief Human Capital Officer (OCHCO)",
-      "event_label": "file_download",
-      "page": "www.va.gov/ohrm/pay/",
-      "total_events": "10521"
-    },
-    {
-      "page_title": "Upcoming Auctions — TreasuryDirect",
-      "event_label": "file_download",
-      "page": "www.treasurydirect.gov/auctions/upcoming/",
-      "total_events": "10441"
-    },
-    {
-      "page_title": "Site Index Search | Internal Revenue Service",
-      "event_label": "file_download",
-      "page": "www.irs.gov/site-index-search?query=941",
-      "total_events": "10182"
-    },
-    {
-      "page_title": "Form MCS-150 and Instructions - Motor Carrier Identification Report | FMCSA",
-      "event_label": "file_download",
-      "page": "www.fmcsa.dot.gov/registration/form-mcs-150-and-instructions-motor-carrier-identification-report",
-      "total_events": "10117"
-    },
-    {
-      "page_title": "Joint Base Pearl Harbor-Hickam Passenger Terminal",
-      "event_label": "file_download",
-      "page": "www.amc.af.mil/AMC-Travel-Site/Terminals/PACOM-Terminals/Joint-Base-Pearl-Harbor-Hickam-Passenger-Terminal/",
-      "total_events": "10068"
-    },
-    {
-      "page_title": "About Form 8936, Qualified Plug-In Electric Drive Motor Vehicle Credit | Internal Revenue Service",
-      "event_label": "file_download",
-      "page": "www.irs.gov/forms-pubs/about-form-8936",
-      "total_events": "10020"
-    },
-    {
-      "page_title": "About Form 8822, Change of Address | Internal Revenue Service",
-      "event_label": "file_download",
-      "page": "www.irs.gov/forms-pubs/about-form-8822",
-      "total_events": "9971"
-    },
-    {
-      "page_title": "CBP DTOPS - Checkout Payment Confirmation",
-      "event_label": "file_download",
-      "page": "dtops.cbp.dhs.gov/main/paymentReturn.html",
-      "total_events": "9890"
-    },
-    {
-      "page_title": "Snow and Ice Forecasts & Services",
-      "event_label": "file_download",
-      "page": "www.weather.gov/lwx/winter",
-      "total_events": "9745"
-    },
-    {
-      "page_title": "Public Disability Benefits Questionnaires (DBQs) - Compensation",
-      "event_label": "file_download",
-      "page": "www.benefits.va.gov/compensation/dbq_publicdbqs.asp",
-      "total_events": "9728"
+      "page_title": "Employment Eligibility Verification | USCIS",
+      "page": "www.uscis.gov/i-9",
+      "linkUrl": "https://www.uscis.gov/sites/default/files/document/forms/i-9instr.pdf",
+      "total_events": "12885"
     },
     {
       "page_title": "Application for Asylum and for Withholding of Removal | USCIS",
-      "event_label": "file_download",
       "page": "www.uscis.gov/i-589",
-      "total_events": "9696"
+      "linkUrl": "https://www.uscis.gov/sites/default/files/document/forms/i-589.pdf",
+      "total_events": "12200"
     },
     {
-      "page_title": "Today's Auction Results — TreasuryDirect",
-      "event_label": "file_download",
-      "page": "www.treasurydirect.gov/auctions/announcements-data-results/announcement-results-press-releases/auction-results/",
-      "total_events": "9696"
-    },
-    {
-      "page_title": "Site Index Search | Internal Revenue Service",
-      "event_label": "file_download",
-      "page": "www.irs.gov/site-index-search?query=940",
-      "total_events": "9680"
+      "page_title": "Army Publishing Directorate",
+      "page": "armypubs.army.mil/productmaps/pubform/details.aspx",
+      "linkUrl": "https://armypubs.army.mil/pub/eforms/dr_a/arn39139-da_form_4856-001-efile-2.pdf",
+      "total_events": "12200"
     },
     {
       "page_title": "Alien’s Change of Address Card | USCIS",
-      "event_label": "file_download",
       "page": "www.uscis.gov/ar-11",
-      "total_events": "9388"
+      "linkUrl": "https://www.uscis.gov/sites/default/files/document/forms/ar-11.pdf",
+      "total_events": "12081"
+    },
+    {
+      "page_title": "About Form W-8 IMY, Certificate of Foreign Intermediary, Foreign Flow-Through Entity, or Certain U.S. Branches for United States Tax Withholding and Reporting | Internal Revenue Service",
+      "page": "www.irs.gov/forms-pubs/about-form-w-8-imy",
+      "linkUrl": "https://www.irs.gov/pub/irs-pdf/fw8imy.pdf",
+      "total_events": "11635"
+    },
+    {
+      "page_title": "Report of Immigration Medical Examination and Vaccination Record | USCIS",
+      "page": "www.uscis.gov/i-693",
+      "linkUrl": "https://www.uscis.gov/sites/default/files/document/forms/i-693.pdf",
+      "total_events": "11516"
+    },
+    {
+      "page_title": "E-Notification of Application/Petition Acceptance | USCIS",
+      "page": "www.uscis.gov/g-1145",
+      "linkUrl": "https://www.uscis.gov/sites/default/files/document/forms/g-1145.pdf",
+      "total_events": "11159"
     },
     {
       "page_title": "About Form 4506-T, Request for Transcript of Tax Return | Internal Revenue Service",
-      "event_label": "file_download",
       "page": "www.irs.gov/forms-pubs/about-form-4506-t",
-      "total_events": "9291"
+      "linkUrl": "https://www.irs.gov/pub/irs-pdf/f4506t.pdf",
+      "total_events": "11070"
     },
     {
-      "page_title": "IRIS Application for TCC | Internal Revenue Service",
-      "event_label": "file_download",
-      "page": "www.irs.gov/tax-professionals/iris-application-for-tcc",
-      "total_events": "9259"
+      "page_title": "BOI E-FILING",
+      "page": "boiefiling.fincen.gov/",
+      "linkUrl": "https://boiefiling.fincen.gov/resources/boir_filing_instructions.pdf",
+      "total_events": "11040"
     },
     {
-      "page_title": "Renew an adult passport | USAGov",
-      "event_label": "file_download",
-      "page": "www.usa.gov/renew-adult-passport",
-      "total_events": "9032"
+      "page_title": "Applicable Federal Rates | Internal Revenue Service",
+      "page": "www.irs.gov/applicable-federal-rates",
+      "linkUrl": "https://www.irs.gov/pub/irs-drop/rr-24-24.pdf",
+      "total_events": "10980"
     },
     {
-      "page_title": "Forms and Pubs Index Search | Internal Revenue Service",
-      "event_label": "file_download",
-      "page": "www.irs.gov/forms-pubs-search?query=1099",
-      "total_events": "8968"
+      "page_title": "Application to Replace Permanent Resident Card (Green Card) | USCIS",
+      "page": "www.uscis.gov/i-90",
+      "linkUrl": "https://www.uscis.gov/sites/default/files/document/forms/i-90.pdf",
+      "total_events": "10980"
     },
     {
-      "page_title": "Defense Finance and Accounting Service > RetiredMilitary > newsevents > newsletter",
-      "event_label": "file_download",
-      "page": "www.dfas.mil/RetiredMilitary/newsevents/newsletter/",
-      "total_events": "8773"
+      "page_title": "Premiums",
+      "page": "www.opm.gov/healthcare-insurance/healthcare/plan-information/premiums/",
+      "linkUrl": "https://www.opm.gov/healthcare-insurance/healthcare/plan-information/premiums/2025/fehb/2025-fehb-ffs-premium-rates.xlsx",
+      "total_events": "10831"
+    },
+    {
+      "page_title": "“Lotería de visas”: averigüe si es elegible y cómo participar | USAGov",
+      "page": "www.usa.gov/es/participar-loteria-visas",
+      "linkUrl": "https://travel.state.gov/content/dam/visas/diversity-visa/dv-instructions-translations/dv-2026-instructions-translations/dv 2026 plain language instructions and faqs.pdf",
+      "total_events": "10742"
+    },
+    {
+      "page_title": "ALEXIS FLORES — FBI",
+      "page": "www.fbi.gov/wanted/topten/alexis-flores",
+      "linkUrl": "https://www.fbi.gov/wanted/topten/alexis-flores/@@download.pdf",
+      "total_events": "10712"
+    },
+    {
+      "page_title": "BHADRESHKUMAR CHETANBHAI PATEL — FBI",
+      "page": "www.fbi.gov/wanted/topten/bhadreshkumar-chetanbhai-patel",
+      "linkUrl": "https://www.fbi.gov/wanted/topten/bhadreshkumar-chetanbhai-patel/@@download.pdf",
+      "total_events": "10712"
+    },
+    {
+      "page_title": "General Schedule",
+      "page": "www.opm.gov/policy-data-oversight/pay-leave/salaries-wages/2024/general-schedule/",
+      "linkUrl": "https://www.opm.gov/policy-data-oversight/pay-leave/salaries-wages/salary-tables/24tables/pdf/rus.pdf",
+      "total_events": "10712"
+    },
+    {
+      "page_title": "About Form W-4V, Voluntary Withholding Request | Internal Revenue Service",
+      "page": "www.irs.gov/forms-pubs/about-form-w-4-v",
+      "linkUrl": "https://www.irs.gov/pub/irs-pdf/fw4v.pdf",
+      "total_events": "10653"
+    },
+    {
+      "page_title": "Application to Register Permanent Residence or Adjust Status | USCIS",
+      "page": "www.uscis.gov/i-485",
+      "linkUrl": "https://www.uscis.gov/sites/default/files/document/forms/i-485instr.pdf",
+      "total_events": "10534"
+    },
+    {
+      "page_title": "CMS 40B | CMS",
+      "page": "www.cms.gov/medicare/cms-forms/cms-forms/cms-forms-items/cms017339",
+      "linkUrl": "https://www.cms.gov/medicare/cms-forms/cms-forms/downloads/cms40b-e.pdf",
+      "total_events": "10474"
+    },
+    {
+      "page_title": "About Form 8822, Change of Address | Internal Revenue Service",
+      "page": "www.irs.gov/forms-pubs/about-form-8822",
+      "linkUrl": "https://www.irs.gov/pub/irs-pdf/f8822.pdf",
+      "total_events": "10445"
+    },
+    {
+      "page_title": "Notice of Entry of Appearance as Attorney or Accredited Representative | USCIS",
+      "page": "www.uscis.gov/g-28",
+      "linkUrl": "https://www.uscis.gov/sites/default/files/document/forms/g-28.pdf",
+      "total_events": "10207"
+    },
+    {
+      "page_title": "FMLA: Forms | U.S. Department of Labor",
+      "page": "www.dol.gov/agencies/whd/fmla/forms",
+      "linkUrl": "https://www.dol.gov/sites/dolgov/files/whd/legacy/files/wh-380-e.pdf",
+      "total_events": "10088"
+    },
+    {
+      "page_title": "RUJA IGNATOVA — FBI",
+      "page": "www.fbi.gov/wanted/topten/ruja-ignatova",
+      "linkUrl": "https://www.fbi.gov/wanted/topten/ruja-ignatova/@@download.pdf",
+      "total_events": "9611"
+    },
+    {
+      "page_title": "Military Compensation > Pay > Basic Pay > Active Duty Pay",
+      "page": "militarypay.defense.gov/pay/basic-pay/active-duty-pay/",
+      "linkUrl": "https://militarypay.defense.gov/portals/3/documents/activedutytables/2024 pay table-capped-final.pdf",
+      "total_events": "9492"
+    },
+    {
+      "page_title": "Request for Fee Waiver | USCIS",
+      "page": "www.uscis.gov/i-912",
+      "linkUrl": "https://www.uscis.gov/sites/default/files/document/forms/i-912instr.pdf",
+      "total_events": "9492"
+    },
+    {
+      "page_title": "Diversity Visa Instructions",
+      "page": "travel.state.gov/content/travel/en/us-visas/immigrate/diversity-visa-program-entry/diversity-visa-instructions.html",
+      "linkUrl": "https://travel.state.gov/content/dam/visas/diversity-visa/dv-instructions-translations/dv-2026-instructions-translations/dv_2026_instructions_ukr.pdf",
+      "total_events": "9463"
+    },
+    {
+      "page_title": "Forms & instructions | Internal Revenue Service",
+      "page": "www.irs.gov/forms-instructions",
+      "linkUrl": "https://www.irs.gov/pub/irs-pdf/f1040.pdf",
+      "total_events": "9284"
+    },
+    {
+      "page_title": "Forms & instructions | Internal Revenue Service",
+      "page": "www.irs.gov/forms-instructions",
+      "linkUrl": "https://www.irs.gov/pub/irs-pdf/i1040gi.pdf",
+      "total_events": "9165"
+    },
+    {
+      "page_title": "General Schedule",
+      "page": "www.opm.gov/policy-data-oversight/pay-leave/salaries-wages/2024/general-schedule",
+      "linkUrl": "https://www.opm.gov/policy-data-oversight/pay-leave/salaries-wages/salary-tables/24tables/pdf/rus.pdf",
+      "total_events": "9165"
+    },
+    {
+      "page_title": "Latest Satellite Imagery",
+      "page": "www.nhc.noaa.gov/satellite.php",
+      "linkUrl": "https://cdn.star.nesdis.noaa.gov/goes16/abi/sector/taw/13/1800x1080.jpg",
+      "total_events": "9016"
+    },
+    {
+      "page_title": "General Schedule",
+      "page": "www.opm.gov/policy-data-oversight/pay-leave/salaries-wages/2024/general-schedule",
+      "linkUrl": "https://www.opm.gov/policy-data-oversight/pay-leave/salaries-wages/salary-tables/24tables/pdf/dcb.pdf",
+      "total_events": "8957"
+    },
+    {
+      "page_title": "Premiums",
+      "page": "www.opm.gov/healthcare-insurance/healthcare/plan-information/premiums/",
+      "linkUrl": "https://www.opm.gov/healthcare-insurance/healthcare/plan-information/premiums/2025/pshb/2025-pshb-ffs-premium-rates.xlsx",
+      "total_events": "8927"
+    },
+    {
+      "page_title": "Premiums",
+      "page": "www.opm.gov/healthcare-insurance/healthcare/plan-information/premiums/",
+      "linkUrl": "https://www.opm.gov/healthcare-insurance/healthcare/plan-information/premiums/2025/fehb/2025-fehb-hmo-premium-rates.xlsx",
+      "total_events": "8868"
+    },
+    {
+      "page_title": "General Schedule",
+      "page": "www.opm.gov/policy-data-oversight/pay-leave/salaries-wages/2024/general-schedule",
+      "linkUrl": "https://www.opm.gov/policy-data-oversight/pay-leave/salaries-wages/salary-tables/24tables/pdf/gs.pdf",
+      "total_events": "8778"
+    },
+    {
+      "page_title": "Beneficial Ownership Information Reporting | FinCEN.gov",
+      "page": "www.fincen.gov/boi",
+      "linkUrl": "https://www.fincen.gov/sites/default/files/shared/boi-informational-brochure-april-2024.pdf",
+      "total_events": "8749"
+    },
+    {
+      "page_title": "Federal Trade Commission Announces Final “Click-to-Cancel” Rule Making It Easier for Consumers to End Recurring Subscriptions and Memberships | Federal Trade Commission",
+      "page": "www.ftc.gov/news-events/news/press-releases/2024/10/federal-trade-commission-announces-final-click-cancel-rule-making-it-easier-consumers-end-recurring",
+      "linkUrl": "https://www.ftc.gov/system/files/ftc_gov/pdf/negoptions-1page-oct2024-v2.pdf",
+      "total_events": "8629"
+    },
+    {
+      "page_title": "Housing Handbooks | HUD.gov / U.S. Department of Housing and Urban Development (HUD)",
+      "page": "www.hud.gov/program_offices/administration/hudclips/handbooks/hsgh",
+      "linkUrl": "https://www.hud.gov/sites/dfiles/ochco/documents/40001-hsgh-update15-052024.pdf",
+      "total_events": "8510"
+    },
+    {
+      "page_title": "Army Publishing Directorate",
+      "page": "armypubs.army.mil/productmaps/pubform/details.aspx",
+      "linkUrl": "https://armypubs.army.mil/pub/eforms/dr_a/arn34523-da_form_5960-000-efile-1.pdf",
+      "total_events": "8332"
+    },
+    {
+      "page_title": "Diversity Visa Instructions",
+      "page": "travel.state.gov/content/travel/en/us-visas/immigrate/diversity-visa-program-entry/diversity-visa-instructions.html",
+      "linkUrl": "https://travel.state.gov/content/dam/visas/diversity-visa/dv-instructions-translations/dv-2026-instructions-translations/dv-2026 instructions_turkish.pdf",
+      "total_events": "8302"
+    },
+    {
+      "page_title": "Form MCS-150 and Instructions - Motor Carrier Identification Report | FMCSA",
+      "page": "www.fmcsa.dot.gov/registration/form-mcs-150-and-instructions-motor-carrier-identification-report",
+      "linkUrl": "https://www.fmcsa.dot.gov/sites/fmcsa.dot.gov/files/2024-04/mcs-150 form.pdf",
+      "total_events": "8302"
+    },
+    {
+      "page_title": "ALEJANDRO ROSALES CASTILLO — FBI",
+      "page": "www.fbi.gov/wanted/topten/alejandro-castillo",
+      "linkUrl": "https://www.fbi.gov/wanted/topten/alejandro-castillo/@@download.pdf",
+      "total_events": "8094"
+    },
+    {
+      "page_title": "Affidavit of Support Under Section 213A of the INA | USCIS",
+      "page": "www.uscis.gov/i-864",
+      "linkUrl": "https://www.uscis.gov/sites/default/files/document/forms/i-864instr.pdf",
+      "total_events": "8094"
+    },
+    {
+      "page_title": "Joint Typhoon Warning Center (JTWC)",
+      "page": "www.metoc.navy.mil/jtwc/jtwc.html",
+      "linkUrl": "https://www.metoc.navy.mil/jtwc/products/abpwweb.txt",
+      "total_events": "7975"
+    },
+    {
+      "page_title": "FMLA: Forms | U.S. Department of Labor",
+      "page": "www.dol.gov/agencies/whd/fmla/forms",
+      "linkUrl": "https://www.dol.gov/sites/dolgov/files/whd/legacy/files/wh-381.pdf",
+      "total_events": "7945"
+    },
+    {
+      "page_title": "Federal Student Aid",
+      "page": "studentaid.gov/manage-loans/forgiveness-cancellation/public-service/public-service-loan-forgiveness-application",
+      "linkUrl": "https://studentaid.gov/sites/default/files/public-service-application-for-forgiveness.pdf",
+      "total_events": "7945"
+    },
+    {
+      "page_title": "About Schedule C (Form 1040), Profit or Loss from Business (Sole Proprietorship) | Internal Revenue Service",
+      "page": "www.irs.gov/forms-pubs/about-schedule-c-form-1040",
+      "linkUrl": "https://www.irs.gov/pub/irs-pdf/f1040sc.pdf",
+      "total_events": "7915"
+    },
+    {
+      "page_title": "Medicare & You | Medicare",
+      "page": "www.medicare.gov/medicare-and-you",
+      "linkUrl": "https://www.medicare.gov/publications/10050-medicare-and-you.pdf",
+      "total_events": "7886"
+    },
+    {
+      "page_title": "VITEL'HOMME INNOCENT — FBI",
+      "page": "www.fbi.gov/wanted/topten/vitelhomme-innocent",
+      "linkUrl": "https://www.fbi.gov/wanted/topten/vitelhomme-innocent/@@download.pdf",
+      "total_events": "7767"
+    },
+    {
+      "page_title": "DoD Directives",
+      "page": "www.esd.whs.mil/directives/issuances/dodd/",
+      "linkUrl": "https://www.esd.whs.mil/portals/54/documents/dd/issuances/dodd/524001p.pdf",
+      "total_events": "7648"
+    },
+    {
+      "page_title": "Premiums",
+      "page": "www.opm.gov/healthcare-insurance/healthcare/plan-information/premiums/",
+      "linkUrl": "https://www.opm.gov/healthcare-insurance/healthcare/plan-information/premiums/2025/fehb/2025-spo-vs-sf-fehb.xlsx",
+      "total_events": "7648"
+    },
+    {
+      "page_title": "Apply for a Child's U.S. Passport",
+      "page": "travel.state.gov/content/travel/en/passports/need-passport/under-16.html",
+      "linkUrl": "https://eforms.state.gov/forms/ds3053.pdf",
+      "total_events": "7618"
+    },
+    {
+      "page_title": "Cost-of-Living Adjustment (COLA) Information | SSA",
+      "page": "www.ssa.gov/cola/",
+      "linkUrl": "https://www.ssa.gov/news/press/factsheets/colafacts2025.pdf",
+      "total_events": "7558"
+    },
+    {
+      "page_title": "About Form 8822-B, Change of Address or Responsible Party - Business | Internal Revenue Service",
+      "page": "www.irs.gov/forms-pubs/about-form-8822-b",
+      "linkUrl": "https://www.irs.gov/pub/irs-pdf/f8822b.pdf",
+      "total_events": "7499"
+    },
+    {
+      "page_title": "Application for Employment Authorization | USCIS",
+      "page": "www.uscis.gov/i-765",
+      "linkUrl": "https://www.uscis.gov/sites/default/files/document/forms/i-765instr.pdf",
+      "total_events": "7499"
+    },
+    {
+      "page_title": "General Schedule",
+      "page": "www.opm.gov/policy-data-oversight/pay-leave/salaries-wages/2024/general-schedule/",
+      "linkUrl": "https://www.opm.gov/policy-data-oversight/pay-leave/salaries-wages/salary-tables/24tables/pdf/gs.pdf",
+      "total_events": "7469"
+    },
+    {
+      "page_title": "About Form 1099-MISC, Miscellaneous Information | Internal Revenue Service",
+      "page": "www.irs.gov/forms-pubs/about-form-1099-misc",
+      "linkUrl": "https://www.irs.gov/pub/irs-pdf/f1099msc.pdf",
+      "total_events": "7350"
+    },
+    {
+      "page_title": "About Form 1040-ES, Estimated Tax for Individuals | Internal Revenue Service",
+      "page": "www.irs.gov/forms-pubs/about-form-1040-es",
+      "linkUrl": "https://www.irs.gov/pub/irs-pdf/f1040es.pdf",
+      "total_events": "7290"
+    },
+    {
+      "page_title": "Growth Charts - Clinical Growth Charts",
+      "page": "www.cdc.gov/growthcharts/cdc-charts.htm",
+      "linkUrl": "https://wcms-wp.cdc.gov/growthcharts/data/set1clinical/cj41c021.pdf",
+      "total_events": "7261"
+    },
+    {
+      "page_title": "About Form SS-4, Application for Employer Identification Number (EIN) | Internal Revenue Service",
+      "page": "www.irs.gov/forms-pubs/about-form-ss-4",
+      "linkUrl": "https://www.irs.gov/pub/irs-pdf/fss4.pdf",
+      "total_events": "7231"
+    },
+    {
+      "page_title": "CMS L564 | CMS",
+      "page": "www.cms.gov/medicare/cms-forms/cms-forms/cms-forms-items/cms009718",
+      "linkUrl": "https://www.cms.gov/medicare/cms-forms/cms-forms/downloads/cms-l564e.pdf",
+      "total_events": "7171"
+    },
+    {
+      "page_title": "Offer in compromise | Internal Revenue Service",
+      "page": "www.irs.gov/payments/offer-in-compromise",
+      "linkUrl": "https://www.irs.gov/pub/irs-pdf/f656b.pdf",
+      "total_events": "7112"
+    },
+    {
+      "page_title": "Search the Physician Fee Schedule | CMS",
+      "page": "www.cms.gov/medicare/physician-fee-schedule/search",
+      "linkUrl": "https://www.cms.gov/files/document/physician-fee-schedule-guide.pdf",
+      "total_events": "7112"
+    },
+    {
+      "page_title": "Premiums",
+      "page": "www.opm.gov/healthcare-insurance/healthcare/plan-information/premiums/",
+      "linkUrl": "https://www.opm.gov/healthcare-insurance/healthcare/plan-information/premiums/2025/pshb/2025-pshb-hmo-premium-rates.xlsx",
+      "total_events": "6814"
+    },
+    {
+      "page_title": "Applicable Federal Rates | Internal Revenue Service",
+      "page": "www.irs.gov/applicable-federal-rates",
+      "linkUrl": "https://www.irs.gov/pub/irs-drop/rr-24-21.pdf",
+      "total_events": "6755"
+    },
+    {
+      "page_title": "Petition to Remove Conditions on Residence | USCIS",
+      "page": "www.uscis.gov/i-751",
+      "linkUrl": "https://www.uscis.gov/sites/default/files/document/forms/i-751.pdf",
+      "total_events": "6755"
+    },
+    {
+      "page_title": "DONALD EUGENE FIELDS II — FBI",
+      "page": "www.fbi.gov/wanted/topten/donald-eugene-fields-ii",
+      "linkUrl": "https://www.fbi.gov/wanted/topten/donald-eugene-fields-ii/@@download.pdf",
+      "total_events": "6695"
+    },
+    {
+      "page_title": "About Form W-7, Application for IRS Individual Taxpayer Identification Number | Internal Revenue Service",
+      "page": "www.irs.gov/forms-pubs/about-form-w-7",
+      "linkUrl": "https://www.irs.gov/pub/irs-pdf/fw7.pdf",
+      "total_events": "6666"
+    },
+    {
+      "page_title": "Site Index Search | Internal Revenue Service",
+      "page": "www.irs.gov/site-index-search?query=941",
+      "linkUrl": "https://www.irs.gov/pub/irs-pdf/f941.pdf",
+      "total_events": "6666"
+    },
+    {
+      "page_title": "Authorization for Credit Card Transactions | USCIS",
+      "page": "www.uscis.gov/g-1450",
+      "linkUrl": "https://www.uscis.gov/sites/default/files/document/forms/g-1450.pdf",
+      "total_events": "6457"
     }
   ],
-  "totals": {},
-  "taken_at": "2024-01-05T15:31:56.695Z"
+  "totals": {
+    "total_events": 1893694
+  },
+  "taken_at": "2024-10-22T19:07:22.648Z"
 }

--- a/ga4-data/live/top-downloads-yesterday.json
+++ b/ga4-data/live/top-downloads-yesterday.json
@@ -3,8 +3,8 @@
   "agency": null,
   "sampling": [
     {
-      "samplesReadCount": "99665609",
-      "samplingSpaceSize": "263594790"
+      "samplesReadCount": "99610675",
+      "samplingSpaceSize": "468808548"
     }
   ],
   "query": {
@@ -33,13 +33,10 @@
         "name": "pageTitle"
       },
       {
-        "name": "eventName"
-      },
-      {
-        "name": "fileName"
-      },
-      {
         "name": "fullPageUrl"
+      },
+      {
+        "name": "linkUrl"
       }
     ],
     "dimensionFilter": {
@@ -89,707 +86,607 @@
   "data": [
     {
       "page_title": "Diversity Visa Instructions",
-      "event_label": "file_download",
-      "file_name": "/content/dam/visas/diversity-visa/dv-instructions-translations/dv-2026-instructions-translations/dv 2026 plain language instructions and faqs.pdf",
       "page": "travel.state.gov/content/travel/en/us-visas/immigrate/diversity-visa-program-entry/diversity-visa-instructions.html",
-      "total_events": "17358"
+      "linkUrl": "https://travel.state.gov/content/dam/visas/diversity-visa/dv-instructions-translations/dv-2026-instructions-translations/dv 2026 plain language instructions and faqs.pdf",
+      "total_events": "17927"
     },
     {
       "page_title": "Diversity Visa Instructions",
-      "event_label": "file_download",
-      "file_name": "/content/dam/visas/diversity-visa/dv-instructions-translations/dv-2025-instructions-translations/dv-2025-instructions.pdf",
       "page": "travel.state.gov/content/travel/en/us-visas/immigrate/diversity-visa-program-entry/diversity-visa-instructions.html",
-      "total_events": "16392"
-    },
-    {
-      "page_title": "BrucePac Recalls Ready-To-Eat Meat and Poultry Products Due to Possible Listeria Contamination | Food Safety and Inspection Service",
-      "event_label": "file_download",
-      "file_name": "/sites/default/files/food_label_pdf/2024-10/recall-028-2024-labels.pdf",
-      "page": "www.fsis.usda.gov/recalls-alerts/brucepac-recalls-ready-eat-meat-and-poultry-products-due-possible-listeria",
-      "total_events": "15038"
-    },
-    {
-      "page_title": "Mars Science Laboratory: Curiosity Rover - NASA Science",
-      "event_label": "file_download",
-      "file_name": "/wp-content/uploads/2024/04/msl-sci-team-key-papers-sept-20-2024.pdf",
-      "page": "science.nasa.gov/mission/msl-curiosity/",
-      "total_events": "5549"
+      "linkUrl": "https://travel.state.gov/content/dam/visas/diversity-visa/dv-instructions-translations/dv-2025-instructions-translations/dv-2025-instructions.pdf",
+      "total_events": "16807"
     },
     {
       "page_title": "BOI E-FILING",
-      "event_label": "file_download",
-      "file_name": "/c8576e94532490750200.pdf",
       "page": "boiefiling.fincen.gov/",
-      "total_events": "4290"
+      "linkUrl": "https://boiefiling.fincen.gov/c8576e94532490750200.pdf",
+      "total_events": "16623"
     },
     {
       "page_title": "BrucePac Recalls Ready-To-Eat Meat and Poultry Products Due to Possible Listeria Contamination | Food Safety and Inspection Service",
-      "event_label": "file_download",
-      "file_name": "/sites/default/files/distro_list/2024-10/rc-028-2024-retail-list.pdf",
       "page": "www.fsis.usda.gov/recalls-alerts/brucepac-recalls-ready-eat-meat-and-poultry-products-due-possible-listeria",
-      "total_events": "3822"
-    },
-    {
-      "page_title": "Affidavit of Support Under Section 213A of the INA | USCIS",
-      "event_label": "file_download",
-      "file_name": "/sites/default/files/document/forms/i-864.pdf",
-      "page": "www.uscis.gov/i-864",
-      "total_events": "3335"
+      "linkUrl": "https://www.fsis.usda.gov/sites/default/files/food_label_pdf/2024-10/recall-028-2024-labels.pdf",
+      "total_events": "15381"
     },
     {
       "page_title": "BrucePac Recalls Ready-To-Eat Meat and Poultry Products Due to Possible Listeria Contamination | Food Safety and Inspection Service",
-      "event_label": "file_download",
-      "file_name": "/sites/default/files/distro_list/2024-10/rc-028-2024-school_distribution_list.pdf",
       "page": "www.fsis.usda.gov/recalls-alerts/brucepac-recalls-ready-eat-meat-and-poultry-products-due-possible-listeria",
-      "total_events": "3084"
+      "linkUrl": "https://www.fsis.usda.gov/sites/default/files/distro_list/2024-10/rc-028-2024-school_distribution_list.pdf",
+      "total_events": "13578"
     },
     {
       "page_title": "Employment Eligibility Verification | USCIS",
-      "event_label": "file_download",
-      "file_name": "/sites/default/files/document/forms/i-9.pdf",
       "page": "www.uscis.gov/i-9",
-      "total_events": "2716"
-    },
-    {
-      "page_title": "Application to Register Permanent Residence or Adjust Status | USCIS",
-      "event_label": "file_download",
-      "file_name": "/sites/default/files/document/forms/i-485.pdf",
-      "page": "www.uscis.gov/i-485",
-      "total_events": "2645"
-    },
-    {
-      "page_title": "Diversity Visa Instructions",
-      "event_label": "file_download",
-      "file_name": "/content/dam/visas/diversity-visa/dv-instructions-translations/dv-2026-instructions-translations/dv-2026 how_to_apply_infographic.pdf",
-      "page": "travel.state.gov/content/travel/en/us-visas/immigrate/diversity-visa-program-entry/diversity-visa-instructions.html",
-      "total_events": "2483"
+      "linkUrl": "https://www.uscis.gov/sites/default/files/document/forms/i-9.pdf",
+      "total_events": "11648"
     },
     {
       "page_title": "Replace Social Security card | SSA",
-      "event_label": "file_download",
-      "file_name": "/forms/ss-5.pdf",
       "page": "www.ssa.gov/number-card/replace-card",
-      "total_events": "2457"
-    },
-    {
-      "page_title": "Petition for Alien Relative | USCIS",
-      "event_label": "file_download",
-      "file_name": "/sites/default/files/document/forms/i-130.pdf",
-      "page": "www.uscis.gov/i-130",
-      "total_events": "2153"
-    },
-    {
-      "page_title": "Army Publishing Directorate",
-      "event_label": "file_download",
-      "file_name": "/pub/eforms/dr_a/arn39139-da_form_4856-001-efile-2.pdf",
-      "page": "armypubs.army.mil/productmaps/pubform/details.aspx",
-      "total_events": "2044"
-    },
-    {
-      "page_title": "Find out if you are eligible for the Diversity Visa (DV) Lottery and how to register | USAGov",
-      "event_label": "file_download",
-      "file_name": "/content/dam/visas/diversity-visa/dv-instructions-translations/dv-2026-instructions-translations/dv 2026 plain language instructions and faqs.pdf",
-      "page": "www.usa.gov/dv-lottery-eligibility",
-      "total_events": "2034"
-    },
-    {
-      "page_title": "Astronomy Picture of the Day",
-      "event_label": "file_download",
-      "file_name": "/apod/image/2410/darkmatter_kipacamnh_1200.jpg",
-      "page": "apod.nasa.gov/apod/astropix.html",
-      "total_events": "1965"
-    },
-    {
-      "page_title": "Passport Forms",
-      "event_label": "file_download",
-      "file_name": "/forms/ds11_pdf.pdf",
-      "page": "travel.state.gov/content/travel/en/passports/how-apply/forms.html",
-      "total_events": "1915"
-    },
-    {
-      "page_title": "Fee Schedule | USCIS",
-      "event_label": "file_download",
-      "file_name": "/sites/default/files/document/forms/g-1055.pdf",
-      "page": "www.uscis.gov/g-1055",
-      "total_events": "1912"
-    },
-    {
-      "page_title": "Application for Employment Authorization | USCIS",
-      "event_label": "file_download",
-      "file_name": "/sites/default/files/document/forms/i-765.pdf",
-      "page": "www.uscis.gov/i-765",
-      "total_events": "1809"
-    },
-    {
-      "page_title": "Request for Fee Waiver | USCIS",
-      "event_label": "file_download",
-      "file_name": "/sites/default/files/document/forms/i-912.pdf",
-      "page": "www.uscis.gov/i-912",
-      "total_events": "1706"
-    },
-    {
-      "page_title": "Growth Charts - Clinical Growth Charts",
-      "event_label": "file_download",
-      "file_name": "/growthcharts/data/set1clinical/cj41c021.pdf",
-      "page": "www.cdc.gov/growthcharts/cdc-charts.htm",
-      "total_events": "1669"
-    },
-    {
-      "page_title": "Diversity Visa Instructions",
-      "event_label": "file_download",
-      "file_name": "/content/dam/visas/diversity-visa/dv-instructions-translations/dv-2026-instructions-translations/dv_2026_instructions_ukr.pdf",
-      "page": "travel.state.gov/content/travel/en/us-visas/immigrate/diversity-visa-program-entry/diversity-visa-instructions.html",
-      "total_events": "1640"
-    },
-    {
-      "page_title": "Change name with Social Security | SSA",
-      "event_label": "file_download",
-      "file_name": "/forms/ss-5.pdf",
-      "page": "www.ssa.gov/personal-record/change-name",
-      "total_events": "1595"
-    },
-    {
-      "page_title": "About Form W-8 IMY, Certificate of Foreign Intermediary, Foreign Flow-Through Entity, or Certain U.S. Branches for United States Tax Withholding and Reporting | Internal Revenue Service",
-      "event_label": "file_download",
-      "file_name": "/pub/irs-pdf/fw8imy.pdf",
-      "page": "www.irs.gov/forms-pubs/about-form-w-8-imy",
-      "total_events": "1500"
-    },
-    {
-      "page_title": "Joint Typhoon Warning Center (JTWC)",
-      "event_label": "file_download",
-      "file_name": "/jtwc/products/wp2224web.txt",
-      "page": "www.metoc.navy.mil/jtwc/jtwc.html",
-      "total_events": "1492"
-    },
-    {
-      "page_title": "Army Publishing Directorate",
-      "event_label": "file_download",
-      "file_name": "/pub/eforms/dr_a/arn34523-da_form_5960-000-efile-1.pdf",
-      "page": "armypubs.army.mil/productmaps/pubform/details.aspx",
-      "total_events": "1449"
-    },
-    {
-      "page_title": "Welcome to the Health Insurance Marketplace® | HealthCare.gov",
-      "event_label": "file_download",
-      "file_name": "/downloads/apply-for-or-renew-coverage.pdf",
-      "page": "www.healthcare.gov/",
-      "total_events": "1412"
+      "linkUrl": "https://www.ssa.gov/forms/ss-5.pdf",
+      "total_events": "7813"
     },
     {
       "page_title": "About Form W-9, Request for Taxpayer Identification Number and Certification | Internal Revenue Service",
-      "event_label": "file_download",
-      "file_name": "/pub/irs-pdf/fw9.pdf",
       "page": "www.irs.gov/forms-pubs/about-form-w-9",
-      "total_events": "1389"
-    },
-    {
-      "page_title": "Application for Naturalization | USCIS",
-      "event_label": "file_download",
-      "file_name": "/sites/default/files/document/forms/n-400.pdf",
-      "page": "www.uscis.gov/n-400",
-      "total_events": "1381"
-    },
-    {
-      "page_title": "ALEXIS FLORES — FBI",
-      "event_label": "file_download",
-      "file_name": "/wanted/topten/alexis-flores/@@download.pdf",
-      "page": "www.fbi.gov/wanted/topten/alexis-flores",
-      "total_events": "1259"
-    },
-    {
-      "page_title": "Application for Travel Documents, Parole Documents, and Arrival/Departure Records | USCIS",
-      "event_label": "file_download",
-      "file_name": "/sites/default/files/document/forms/i-131.pdf",
-      "page": "www.uscis.gov/i-131",
-      "total_events": "1222"
-    },
-    {
-      "page_title": "Small Entity Compliance Guide | FinCEN.gov",
-      "event_label": "file_download",
-      "file_name": "/sites/default/files/shared/boi_small_compliance_guide.v1.1-final.pdf",
-      "page": "www.fincen.gov/boi/small-entity-compliance-guide",
-      "total_events": "1217"
-    },
-    {
-      "page_title": "About Form 1040, U.S. Individual Income Tax Return | Internal Revenue Service",
-      "event_label": "file_download",
-      "file_name": "/pub/irs-pdf/f1040.pdf",
-      "page": "www.irs.gov/forms-pubs/about-form-1040",
-      "total_events": "1214"
-    },
-    {
-      "page_title": "Diversity Visa Instructions",
-      "event_label": "file_download",
-      "file_name": "/content/dam/visas/diversity-visa/dv-instructions-translations/dv-2026-instructions-translations/dv-2026 instructions_turkish.pdf",
-      "page": "travel.state.gov/content/travel/en/us-visas/immigrate/diversity-visa-program-entry/diversity-visa-instructions.html",
-      "total_events": "1209"
-    },
-    {
-      "page_title": "Latest Satellite Imagery",
-      "event_label": "file_download",
-      "file_name": "/goes16/abi/sector/taw/13/1800x1080.jpg",
-      "page": "www.nhc.noaa.gov/satellite.php",
-      "total_events": "1203"
-    },
-    {
-      "page_title": "Latest Satellite Imagery",
-      "event_label": "file_download",
-      "file_name": "/goes16/abi/sector/car/13/1000x1000.jpg",
-      "page": "www.nhc.noaa.gov/satellite.php",
-      "total_events": "1108"
-    },
-    {
-      "page_title": "Joint Typhoon Warning Center (JTWC)",
-      "event_label": "file_download",
-      "file_name": "/jtwc/products/abpwweb.txt",
-      "page": "www.metoc.navy.mil/jtwc/jtwc.html",
-      "total_events": "1098"
-    },
-    {
-      "page_title": "Application to Register Permanent Residence or Adjust Status | USCIS",
-      "event_label": "file_download",
-      "file_name": "/sites/default/files/document/forms/i-485instr.pdf",
-      "page": "www.uscis.gov/i-485",
-      "total_events": "1084"
-    },
-    {
-      "page_title": "BHADRESHKUMAR CHETANBHAI PATEL — FBI",
-      "event_label": "file_download",
-      "file_name": "/wanted/topten/bhadreshkumar-chetanbhai-patel/@@download.pdf",
-      "page": "www.fbi.gov/wanted/topten/bhadreshkumar-chetanbhai-patel",
-      "total_events": "1034"
-    },
-    {
-      "page_title": "Replacement card | SSA",
-      "event_label": "file_download",
-      "file_name": "/forms/ss-5.pdf",
-      "page": "www.ssa.gov/number-card/replace-card/get-started/applicant",
-      "total_events": "1024"
-    },
-    {
-      "page_title": "Joint Typhoon Warning Center (JTWC)",
-      "event_label": "file_download",
-      "file_name": "/jtwc/products/wp9624web.txt",
-      "page": "www.metoc.navy.mil/jtwc/jtwc.html",
-      "total_events": "1018"
-    },
-    {
-      "page_title": "Application to Replace Permanent Resident Card (Green Card) | USCIS",
-      "event_label": "file_download",
-      "file_name": "/sites/default/files/document/forms/i-90.pdf",
-      "page": "www.uscis.gov/i-90",
-      "total_events": "1005"
-    },
-    {
-      "page_title": "RUJA IGNATOVA — FBI",
-      "event_label": "file_download",
-      "file_name": "/wanted/topten/ruja-ignatova/@@download.pdf",
-      "page": "www.fbi.gov/wanted/topten/ruja-ignatova",
-      "total_events": "1000"
-    },
-    {
-      "page_title": "Application for Asylum and for Withholding of Removal | USCIS",
-      "event_label": "file_download",
-      "file_name": "/sites/default/files/document/forms/i-589.pdf",
-      "page": "www.uscis.gov/i-589",
-      "total_events": "997"
-    },
-    {
-      "page_title": "E-Notification of Application/Petition Acceptance | USCIS",
-      "event_label": "file_download",
-      "file_name": "/sites/default/files/document/forms/g-1145.pdf",
-      "page": "www.uscis.gov/g-1145",
-      "total_events": "987"
-    },
-    {
-      "page_title": "About Form W-4, Employee's Withholding Certificate | Internal Revenue Service",
-      "event_label": "file_download",
-      "file_name": "/pub/irs-pdf/fw4.pdf",
-      "page": "www.irs.gov/forms-pubs/about-form-w-4",
-      "total_events": "979"
-    },
-    {
-      "page_title": "Military Compensation > Pay > Basic Pay > Active Duty Pay",
-      "event_label": "file_download",
-      "file_name": "/portals/3/documents/activedutytables/2024 pay table-capped-final.pdf",
-      "page": "militarypay.defense.gov/pay/basic-pay/active-duty-pay/",
-      "total_events": "973"
-    },
-    {
-      "page_title": "“Lotería de visas”: averigüe si es elegible y cómo participar | USAGov",
-      "event_label": "file_download",
-      "file_name": "/content/dam/visas/diversity-visa/dv-instructions-translations/dv-2026-instructions-translations/dv 2026 plain language instructions and faqs.pdf",
-      "page": "www.usa.gov/es/participar-loteria-visas",
-      "total_events": "960"
+      "linkUrl": "https://www.irs.gov/pub/irs-pdf/fw9.pdf",
+      "total_events": "7328"
     },
     {
       "page_title": "Affidavit of Support Under Section 213A of the INA | USCIS",
-      "event_label": "file_download",
-      "file_name": "/sites/default/files/document/forms/i-864instr.pdf",
       "page": "www.uscis.gov/i-864",
-      "total_events": "915"
+      "linkUrl": "https://www.uscis.gov/sites/default/files/document/forms/i-864.pdf",
+      "total_events": "5629"
     },
     {
-      "page_title": "BOI E-FILING",
-      "event_label": "file_download",
-      "file_name": "/c8576e94532490750200.pdf",
-      "page": "boiefiling.fincen.gov/fileboir",
-      "total_events": "915"
+      "page_title": "Small Entity Compliance Guide | FinCEN.gov",
+      "page": "www.fincen.gov/boi/small-entity-compliance-guide",
+      "linkUrl": "https://www.fincen.gov/sites/default/files/shared/boi_small_compliance_guide.v1.1-final.pdf",
+      "total_events": "5389"
     },
     {
-      "page_title": "Cost-of-Living Adjustment (COLA) Information | SSA",
-      "event_label": "file_download",
-      "file_name": "/news/press/factsheets/colafacts2025.pdf",
-      "page": "www.ssa.gov/cola/",
-      "total_events": "905"
+      "page_title": "Application to Register Permanent Residence or Adjust Status | USCIS",
+      "page": "www.uscis.gov/i-485",
+      "linkUrl": "https://www.uscis.gov/sites/default/files/document/forms/i-485.pdf",
+      "total_events": "5262"
     },
     {
-      "page_title": "Latest Satellite Imagery",
-      "event_label": "file_download",
-      "file_name": "/goes16/abi/sector/car/geocolor/1000x1000.jpg",
-      "page": "www.nhc.noaa.gov/satellite.php",
-      "total_events": "899"
+      "page_title": "SEC.gov | SEC Division of Examinations Announces 2025 Priorities",
+      "page": "www.sec.gov/newsroom/press-releases/2024-172",
+      "linkUrl": "https://www.sec.gov/files/2025-exam-priorities.pdf",
+      "total_events": "4838"
     },
     {
-      "page_title": "APOD: 2024 October 20 – Dark Matter in a Simulated Universe",
-      "event_label": "file_download",
-      "file_name": "/apod/image/2410/darkmatter_kipacamnh_1200.jpg",
-      "page": "apod.nasa.gov/apod/ap241020.html",
-      "total_events": "894"
-    },
-    {
-      "page_title": "Petition to Remove Conditions on Residence | USCIS",
-      "event_label": "file_download",
-      "file_name": "/sites/default/files/document/forms/i-751.pdf",
-      "page": "www.uscis.gov/i-751",
-      "total_events": "891"
-    },
-    {
-      "page_title": "General Schedule",
-      "event_label": "file_download",
-      "file_name": "/policy-data-oversight/pay-leave/salaries-wages/salary-tables/24tables/pdf/rus.pdf",
-      "page": "www.opm.gov/policy-data-oversight/pay-leave/salaries-wages/2024/general-schedule/",
-      "total_events": "883"
-    },
-    {
-      "page_title": "General Schedule",
-      "event_label": "file_download",
-      "file_name": "/policy-data-oversight/pay-leave/salaries-wages/salary-tables/24tables/pdf/dcb.pdf",
-      "page": "www.opm.gov/policy-data-oversight/pay-leave/salaries-wages/2024/general-schedule/",
-      "total_events": "873"
-    },
-    {
-      "page_title": "ALEJANDRO ROSALES CASTILLO — FBI",
-      "event_label": "file_download",
-      "file_name": "/wanted/topten/alejandro-castillo/@@download.pdf",
-      "page": "www.fbi.gov/wanted/topten/alejandro-castillo",
-      "total_events": "862"
-    },
-    {
-      "page_title": "Joint Typhoon Warning Center (JTWC)",
-      "event_label": "file_download",
-      "file_name": "/jtwc/products/wp2224prog.txt",
-      "page": "www.metoc.navy.mil/jtwc/jtwc.html",
-      "total_events": "860"
-    },
-    {
-      "page_title": "Premiums",
-      "event_label": "file_download",
-      "file_name": "/healthcare-insurance/healthcare/plan-information/premiums/2025/fehb/2025-fehb-ffs-premium-rates.xlsx",
-      "page": "www.opm.gov/healthcare-insurance/healthcare/plan-information/premiums/",
-      "total_events": "854"
-    },
-    {
-      "page_title": "VITEL'HOMME INNOCENT — FBI",
-      "event_label": "file_download",
-      "file_name": "/wanted/topten/vitelhomme-innocent/@@download.pdf",
-      "page": "www.fbi.gov/wanted/topten/vitelhomme-innocent",
-      "total_events": "825"
-    },
-    {
-      "page_title": "Petition for Alien Fiancé(e) | USCIS",
-      "event_label": "file_download",
-      "file_name": "/sites/default/files/document/forms/i-129f.pdf",
-      "page": "www.uscis.gov/i-129f",
-      "total_events": "778"
-    },
-    {
-      "page_title": "Declaration of Financial Support | USCIS",
-      "event_label": "file_download",
-      "file_name": "/sites/default/files/document/forms/i-134.pdf",
-      "page": "www.uscis.gov/i-134",
-      "total_events": "767"
-    },
-    {
-      "page_title": "About Form W-2, Wage and Tax Statement | Internal Revenue Service",
-      "event_label": "file_download",
-      "file_name": "/pub/irs-pdf/fw2.pdf",
-      "page": "www.irs.gov/forms-pubs/about-form-w-2",
-      "total_events": "754"
-    },
-    {
-      "page_title": "Premiums",
-      "event_label": "file_download",
-      "file_name": "/healthcare-insurance/healthcare/plan-information/premiums/2025/fehb/2025-fehb-hmo-premium-rates.xlsx",
-      "page": "www.opm.gov/healthcare-insurance/healthcare/plan-information/premiums/",
-      "total_events": "751"
-    },
-    {
-      "page_title": "About Form 941, Employer's Quarterly Federal Tax Return | Internal Revenue Service",
-      "event_label": "file_download",
-      "file_name": "/pub/irs-pdf/f941.pdf",
-      "page": "www.irs.gov/forms-pubs/about-form-941",
-      "total_events": "748"
-    },
-    {
-      "page_title": "Alien’s Change of Address Card | USCIS",
-      "event_label": "file_download",
-      "file_name": "/sites/default/files/document/forms/ar-11.pdf",
-      "page": "www.uscis.gov/ar-11",
-      "total_events": "738"
-    },
-    {
-      "page_title": "Green Card | USCIS",
-      "event_label": "file_download",
-      "file_name": "/sites/default/files/document/guides/greencard_comparison_en.pdf.pdf",
-      "page": "www.uscis.gov/green-card",
-      "total_events": "738"
-    },
-    {
-      "page_title": "About Form 1040-ES, Estimated Tax for Individuals | Internal Revenue Service",
-      "event_label": "file_download",
-      "file_name": "/pub/irs-pdf/f1040es.pdf",
-      "page": "www.irs.gov/forms-pubs/about-form-1040-es",
-      "total_events": "714"
-    },
-    {
-      "page_title": "Report of Immigration Medical Examination and Vaccination Record | USCIS",
-      "event_label": "file_download",
-      "file_name": "/sites/default/files/document/forms/i-693.pdf",
-      "page": "www.uscis.gov/i-693",
-      "total_events": "701"
-    },
-    {
-      "page_title": "CBP Form 6059B Customs Declaration - English (Fillable) | U.S. Customs and Border Protection",
-      "event_label": "file_download",
-      "file_name": "/sites/default/files/2024-07/cbp_form_6059b_english_0.pdf",
-      "page": "www.cbp.gov/document/forms/form-6059b-customs-declaration-english-fillable",
-      "total_events": "698"
-    },
-    {
-      "page_title": "Medicare & You | Medicare",
-      "event_label": "file_download",
-      "file_name": "/publications/10050-medicare-and-you.pdf",
-      "page": "www.medicare.gov/medicare-and-you",
-      "total_events": "696"
-    },
-    {
-      "page_title": "Authorization for Credit Card Transactions | USCIS",
-      "event_label": "file_download",
-      "file_name": "/sites/default/files/document/forms/g-1450.pdf",
-      "page": "www.uscis.gov/g-1450",
-      "total_events": "688"
-    },
-    {
-      "page_title": "DONALD EUGENE FIELDS II — FBI",
-      "event_label": "file_download",
-      "file_name": "/wanted/topten/donald-eugene-fields-ii/@@download.pdf",
-      "page": "www.fbi.gov/wanted/topten/donald-eugene-fields-ii",
-      "total_events": "688"
-    },
-    {
-      "page_title": "Joint Typhoon Warning Center (JTWC)",
-      "event_label": "file_download",
-      "file_name": "/jtwc/products/96w_191500sair.jpg",
-      "page": "www.metoc.navy.mil/jtwc/jtwc.html",
-      "total_events": "688"
-    },
-    {
-      "page_title": "Employment Eligibility Verification | USCIS",
-      "event_label": "file_download",
-      "file_name": "/sites/default/files/document/forms/i-9instr.pdf",
-      "page": "www.uscis.gov/i-9",
-      "total_events": "685"
-    },
-    {
-      "page_title": "Latest Satellite Imagery",
-      "event_label": "file_download",
-      "file_name": "/goes16/abi/sector/taw/geocolor/1800x1080.jpg",
-      "page": "www.nhc.noaa.gov/satellite.php",
-      "total_events": "685"
-    },
-    {
-      "page_title": "Premiums",
-      "event_label": "file_download",
-      "file_name": "/healthcare-insurance/healthcare/plan-information/premiums/2025/pshb/2025-pshb-ffs-premium-rates.xlsx",
-      "page": "www.opm.gov/healthcare-insurance/healthcare/plan-information/premiums/",
-      "total_events": "682"
-    },
-    {
-      "page_title": "About Form W-4V, Voluntary Withholding Request | Internal Revenue Service",
-      "event_label": "file_download",
-      "file_name": "/pub/irs-pdf/fw4v.pdf",
-      "page": "www.irs.gov/forms-pubs/about-form-w-4-v",
-      "total_events": "677"
-    },
-    {
-      "page_title": "Apply for a Child's U.S. Passport",
-      "event_label": "file_download",
-      "file_name": "/forms/ds3053.pdf",
-      "page": "travel.state.gov/content/travel/en/passports/need-passport/under-16.html",
-      "total_events": "669"
-    },
-    {
-      "page_title": "APOD: 2024 October 19 - Comet Tsuchinshan ATLAS Flys Away",
-      "event_label": "file_download",
-      "file_name": "/apod/image/2410/c2023a3-in-the-past-6-days.jpg",
-      "page": "apod.nasa.gov/apod/ap241019.html",
-      "total_events": "666"
-    },
-    {
-      "page_title": "Forms & instructions | Internal Revenue Service",
-      "event_label": "file_download",
-      "file_name": "/pub/irs-pdf/f1040.pdf",
-      "page": "www.irs.gov/forms-instructions",
-      "total_events": "666"
-    },
-    {
-      "page_title": "Application for Naturalization | USCIS",
-      "event_label": "file_download",
-      "file_name": "/sites/default/files/document/forms/n-400instr.pdf",
-      "page": "www.uscis.gov/n-400",
-      "total_events": "664"
-    },
-    {
-      "page_title": "Growth Charts - Clinical Growth Charts",
-      "event_label": "file_download",
-      "file_name": "/growthcharts/data/set1clinical/cj41c022.pdf",
-      "page": "www.cdc.gov/growthcharts/cdc-charts.htm",
-      "total_events": "645"
-    },
-    {
-      "page_title": "Premiums",
-      "event_label": "file_download",
-      "file_name": "/healthcare-insurance/healthcare/plan-information/premiums/2025/pshb/2025-pshb-hmo-premium-rates.xlsx",
-      "page": "www.opm.gov/healthcare-insurance/healthcare/plan-information/premiums/",
-      "total_events": "624"
-    },
-    {
-      "page_title": "Latest Satellite Imagery",
-      "event_label": "file_download",
-      "file_name": "/goes16/abi/sector/gm/geocolor/1000x1000.jpg",
-      "page": "www.nhc.noaa.gov/satellite.php",
-      "total_events": "614"
-    },
-    {
-      "page_title": "Immigrant Petition for Alien Workers | USCIS",
-      "event_label": "file_download",
-      "file_name": "/sites/default/files/document/forms/i-140.pdf",
-      "page": "www.uscis.gov/i-140",
-      "total_events": "611"
-    },
-    {
-      "page_title": "Applicable Federal Rates | Internal Revenue Service",
-      "event_label": "file_download",
-      "file_name": "/pub/irs-drop/rr-24-24.pdf",
-      "page": "www.irs.gov/applicable-federal-rates",
-      "total_events": "608"
+      "page_title": "Change name with Social Security | SSA",
+      "page": "www.ssa.gov/personal-record/change-name",
+      "linkUrl": "https://www.ssa.gov/forms/ss-5.pdf",
+      "total_events": "4551"
     },
     {
       "page_title": "Application for Employment Authorization | USCIS",
-      "event_label": "file_download",
-      "file_name": "/sites/default/files/document/forms/i-765instr.pdf",
       "page": "www.uscis.gov/i-765",
-      "total_events": "598"
+      "linkUrl": "https://www.uscis.gov/sites/default/files/document/forms/i-765.pdf",
+      "total_events": "4504"
     },
     {
-      "page_title": "About Form 8822, Change of Address | Internal Revenue Service",
-      "event_label": "file_download",
-      "file_name": "/pub/irs-pdf/f8822.pdf",
-      "page": "www.irs.gov/forms-pubs/about-form-8822",
-      "total_events": "587"
+      "page_title": "Passport Forms",
+      "page": "travel.state.gov/content/travel/en/passports/how-apply/forms.html",
+      "linkUrl": "https://eforms.state.gov/forms/ds11_pdf.pdf",
+      "total_events": "4278"
     },
     {
-      "page_title": "Reserve Drill Pay",
-      "event_label": "file_download",
-      "file_name": "/portals/3/documents/activedutytables/2024 pay table w drill pay - 1 drill period.pdf",
-      "page": "militarypay.defense.gov/pay/basic-pay/reserve-drill-pay/",
-      "total_events": "584"
+      "page_title": "Fee Schedule | USCIS",
+      "page": "www.uscis.gov/g-1055",
+      "linkUrl": "https://www.uscis.gov/sites/default/files/document/forms/g-1055.pdf",
+      "total_events": "4179"
     },
     {
-      "page_title": "A Week With the DASH Eating Plan | NHLBI, NIH",
-      "event_label": "file_download",
-      "file_name": "/sites/default/files/publications/weekondash.pdf",
-      "page": "www.nhlbi.nih.gov/resources/week-dash-eating-plan",
-      "total_events": "579"
+      "page_title": "Inactivated Influenza Vaccine Information Statement | CDC",
+      "page": "www.cdc.gov/vaccines/hcp/vis/vis-statements/flu.html",
+      "linkUrl": "https://www.cdc.gov/vaccines/hcp/vis/vis-statements/flu.pdf",
+      "total_events": "4118"
     },
     {
-      "page_title": "Petition to Remove Conditions on Residence | USCIS",
-      "event_label": "file_download",
-      "file_name": "/sites/default/files/document/forms/i-751instr.pdf",
-      "page": "www.uscis.gov/i-751",
-      "total_events": "555"
+      "page_title": "BrucePac Recalls Ready-To-Eat Meat and Poultry Products Due to Possible Listeria Contamination | Food Safety and Inspection Service",
+      "page": "www.fsis.usda.gov/recalls-alerts/brucepac-recalls-ready-eat-meat-and-poultry-products-due-possible-listeria",
+      "linkUrl": "https://www.fsis.usda.gov/sites/default/files/distro_list/2024-10/rc-028-2024-retail-list.pdf",
+      "total_events": "3600"
     },
     {
-      "page_title": "General Schedule",
-      "event_label": "file_download",
-      "file_name": "/policy-data-oversight/pay-leave/salaries-wages/salary-tables/24tables/pdf/gs.pdf",
-      "page": "www.opm.gov/policy-data-oversight/pay-leave/salaries-wages/2024/general-schedule/",
-      "total_events": "553"
-    },
-    {
-      "page_title": "Rebecca's Business Plan Template - Traditional | U.S. Small Business Administration",
-      "event_label": "file_download",
-      "file_name": "/sites/default/files/2023-08/sample business plan - we can do it consulting (4).doc",
-      "page": "www.sba.gov/document/support-rebeccas-business-plan-template-traditional",
-      "total_events": "550"
+      "page_title": "Petition for Alien Relative | USCIS",
+      "page": "www.uscis.gov/i-130",
+      "linkUrl": "https://www.uscis.gov/sites/default/files/document/forms/i-130.pdf",
+      "total_events": "3591"
     },
     {
       "page_title": "BOI E-FILING",
-      "event_label": "file_download",
-      "file_name": "/resources/boir_filing_instructions.pdf",
-      "page": "boiefiling.fincen.gov/",
-      "total_events": "547"
+      "page": "boiefiling.fincen.gov/fileboir",
+      "linkUrl": "https://boiefiling.fincen.gov/c8576e94532490750200.pdf",
+      "total_events": "3544"
+    },
+    {
+      "page_title": "Astronomy Picture of the Day",
+      "page": "apod.nasa.gov/apod/astropix.html",
+      "linkUrl": "https://apod.nasa.gov/apod/image/2410/cometa3_fulda_2549.jpg",
+      "total_events": "3473"
+    },
+    {
+      "page_title": "About Form W-4, Employee's Withholding Certificate | Internal Revenue Service",
+      "page": "www.irs.gov/forms-pubs/about-form-w-4",
+      "linkUrl": "https://www.irs.gov/pub/irs-pdf/fw4.pdf",
+      "total_events": "3450"
+    },
+    {
+      "page_title": "Welcome to the Health Insurance Marketplace® | HealthCare.gov",
+      "page": "www.healthcare.gov/",
+      "linkUrl": "https://www.healthcare.gov/downloads/apply-for-or-renew-coverage.pdf",
+      "total_events": "3379"
+    },
+    {
+      "page_title": "Application for Travel Documents, Parole Documents, and Arrival/Departure Records | USCIS",
+      "page": "www.uscis.gov/i-131",
+      "linkUrl": "https://www.uscis.gov/sites/default/files/document/forms/i-131.pdf",
+      "total_events": "2965"
+    },
+    {
+      "page_title": "Request for Fee Waiver | USCIS",
+      "page": "www.uscis.gov/i-912",
+      "linkUrl": "https://www.uscis.gov/sites/default/files/document/forms/i-912.pdf",
+      "total_events": "2956"
+    },
+    {
+      "page_title": "Application for Naturalization | USCIS",
+      "page": "www.uscis.gov/n-400",
+      "linkUrl": "https://www.uscis.gov/sites/default/files/document/forms/n-400.pdf",
+      "total_events": "2763"
+    },
+    {
+      "page_title": "Replacement card | SSA",
+      "page": "www.ssa.gov/number-card/replace-card/get-started/applicant",
+      "linkUrl": "https://www.ssa.gov/forms/ss-5.pdf",
+      "total_events": "2683"
+    },
+    {
+      "page_title": "About Form 941, Employer's Quarterly Federal Tax Return | Internal Revenue Service",
+      "page": "www.irs.gov/forms-pubs/about-form-941",
+      "linkUrl": "https://www.irs.gov/pub/irs-pdf/f941.pdf",
+      "total_events": "2678"
+    },
+    {
+      "page_title": "Employment Eligibility Verification | USCIS",
+      "page": "www.uscis.gov/i-9",
+      "linkUrl": "https://www.uscis.gov/sites/default/files/document/forms/i-9instr.pdf",
+      "total_events": "2659"
+    },
+    {
+      "page_title": "About Form W-2, Wage and Tax Statement | Internal Revenue Service",
+      "page": "www.irs.gov/forms-pubs/about-form-w-2",
+      "linkUrl": "https://www.irs.gov/pub/irs-pdf/fw2.pdf",
+      "total_events": "2640"
+    },
+    {
+      "page_title": "About Form 1040, U.S. Individual Income Tax Return | Internal Revenue Service",
+      "page": "www.irs.gov/forms-pubs/about-form-1040",
+      "linkUrl": "https://www.irs.gov/pub/irs-pdf/f1040.pdf",
+      "total_events": "2593"
+    },
+    {
+      "page_title": "Diversity Visa Instructions",
+      "page": "travel.state.gov/content/travel/en/us-visas/immigrate/diversity-visa-program-entry/diversity-visa-instructions.html",
+      "linkUrl": "https://travel.state.gov/content/dam/visas/diversity-visa/dv-instructions-translations/dv-2026-instructions-translations/dv-2026 how_to_apply_infographic.pdf",
+      "total_events": "2579"
+    },
+    {
+      "page_title": "Applicable Federal Rates | Internal Revenue Service",
+      "page": "www.irs.gov/applicable-federal-rates",
+      "linkUrl": "https://www.irs.gov/pub/irs-drop/rr-24-24.pdf",
+      "total_events": "2410"
     },
     {
       "page_title": "Joint Typhoon Warning Center (JTWC)",
-      "event_label": "file_download",
-      "file_name": "/jtwc/products/abioweb.txt",
       "page": "www.metoc.navy.mil/jtwc/jtwc.html",
-      "total_events": "540"
+      "linkUrl": "https://www.metoc.navy.mil/jtwc/products/wp2224web.txt",
+      "total_events": "2268"
     },
     {
-      "page_title": "(not set)",
-      "event_label": "file_download",
-      "file_name": "/pitqj5emwdvc/41irxjcdfdpsj9qswibajo/e92c2ae04802641223f63589926d080e/philippines_imp.notice_english.pdf",
-      "page": "www.ustraveldocs.com/ph/en/nonimmigrant-visa",
-      "total_events": "534"
+      "page_title": "Report of Immigration Medical Examination and Vaccination Record | USCIS",
+      "page": "www.uscis.gov/i-693",
+      "linkUrl": "https://www.uscis.gov/sites/default/files/document/forms/i-693.pdf",
+      "total_events": "2240"
     },
     {
-      "page_title": "Contract Between Sponsor and Household Member | USCIS",
-      "event_label": "file_download",
-      "file_name": "/sites/default/files/document/forms/i-864a.pdf",
-      "page": "www.uscis.gov/i-864a",
-      "total_events": "532"
+      "page_title": "BOI E-FILING",
+      "page": "boiefiling.fincen.gov/",
+      "linkUrl": "https://boiefiling.fincen.gov/resources/boir_filing_instructions.pdf",
+      "total_events": "2221"
     },
     {
-      "page_title": "Ramstein AB Passenger Terminal",
-      "event_label": "file_download",
-      "file_name": "/portals/12/amc tvl pg/passenger terminals/european command terminals/ramstein ab passenger terminal/72 hr - ramstein afpims with pet info (1).pdf",
-      "page": "www.amc.af.mil/amc-travel-site/terminals/eucom-terminals/ramstein-ab-passenger-terminal/",
-      "total_events": "526"
+      "page_title": "FMLA: Forms | U.S. Department of Labor",
+      "page": "www.dol.gov/agencies/whd/fmla/forms",
+      "linkUrl": "https://www.dol.gov/sites/dolgov/files/whd/legacy/files/wh-380-e.pdf",
+      "total_events": "2212"
+    },
+    {
+      "page_title": "CMS 40B | CMS",
+      "page": "www.cms.gov/medicare/cms-forms/cms-forms/cms-forms-items/cms017339",
+      "linkUrl": "https://www.cms.gov/medicare/cms-forms/cms-forms/downloads/cms40b-e.pdf",
+      "total_events": "2193"
+    },
+    {
+      "page_title": "Application to Replace Permanent Resident Card (Green Card) | USCIS",
+      "page": "www.uscis.gov/i-90",
+      "linkUrl": "https://www.uscis.gov/sites/default/files/document/forms/i-90.pdf",
+      "total_events": "2179"
+    },
+    {
+      "page_title": "Beneficial Ownership Information Reporting | FinCEN.gov",
+      "page": "www.fincen.gov/boi",
+      "linkUrl": "https://www.fincen.gov/sites/default/files/shared/boi-informational-brochure-april-2024.pdf",
+      "total_events": "2179"
+    },
+    {
+      "page_title": "Application for Asylum and for Withholding of Removal | USCIS",
+      "page": "www.uscis.gov/i-589",
+      "linkUrl": "https://www.uscis.gov/sites/default/files/document/forms/i-589.pdf",
+      "total_events": "2151"
+    },
+    {
+      "page_title": "General Schedule",
+      "page": "www.opm.gov/policy-data-oversight/pay-leave/salaries-wages/2024/general-schedule/",
+      "linkUrl": "https://www.opm.gov/policy-data-oversight/pay-leave/salaries-wages/salary-tables/24tables/pdf/dcb.pdf",
+      "total_events": "2151"
+    },
+    {
+      "page_title": "Growth Charts - Clinical Growth Charts",
+      "page": "www.cdc.gov/growthcharts/cdc-charts.htm",
+      "linkUrl": "https://wcms-wp.cdc.gov/growthcharts/data/set1clinical/cj41c021.pdf",
+      "total_events": "2151"
+    },
+    {
+      "page_title": "Alien’s Change of Address Card | USCIS",
+      "page": "www.uscis.gov/ar-11",
+      "linkUrl": "https://www.uscis.gov/sites/default/files/document/forms/ar-11.pdf",
+      "total_events": "2108"
+    },
+    {
+      "page_title": "About Form 4506-T, Request for Transcript of Tax Return | Internal Revenue Service",
+      "page": "www.irs.gov/forms-pubs/about-form-4506-t",
+      "linkUrl": "https://www.irs.gov/pub/irs-pdf/f4506t.pdf",
+      "total_events": "2038"
+    },
+    {
+      "page_title": "Find out if you are eligible for the Diversity Visa (DV) Lottery and how to register | USAGov",
+      "page": "www.usa.gov/dv-lottery-eligibility",
+      "linkUrl": "https://travel.state.gov/content/dam/visas/diversity-visa/dv-instructions-translations/dv-2026-instructions-translations/dv 2026 plain language instructions and faqs.pdf",
+      "total_events": "2019"
+    },
+    {
+      "page_title": "General Schedule",
+      "page": "www.opm.gov/policy-data-oversight/pay-leave/salaries-wages/2024/general-schedule",
+      "linkUrl": "https://www.opm.gov/policy-data-oversight/pay-leave/salaries-wages/salary-tables/24tables/pdf/rus.pdf",
+      "total_events": "1972"
+    },
+    {
+      "page_title": "About Form 8822, Change of Address | Internal Revenue Service",
+      "page": "www.irs.gov/forms-pubs/about-form-8822",
+      "linkUrl": "https://www.irs.gov/pub/irs-pdf/f8822.pdf",
+      "total_events": "1967"
+    },
+    {
+      "page_title": "About Form W-4V, Voluntary Withholding Request | Internal Revenue Service",
+      "page": "www.irs.gov/forms-pubs/about-form-w-4-v",
+      "linkUrl": "https://www.irs.gov/pub/irs-pdf/fw4v.pdf",
+      "total_events": "1967"
+    },
+    {
+      "page_title": "E-Notification of Application/Petition Acceptance | USCIS",
+      "page": "www.uscis.gov/g-1145",
+      "linkUrl": "https://www.uscis.gov/sites/default/files/document/forms/g-1145.pdf",
+      "total_events": "1901"
+    },
+    {
+      "page_title": "Notice of Entry of Appearance as Attorney or Accredited Representative | USCIS",
+      "page": "www.uscis.gov/g-28",
+      "linkUrl": "https://www.uscis.gov/sites/default/files/document/forms/g-28.pdf",
+      "total_events": "1901"
+    },
+    {
+      "page_title": "Application to Register Permanent Residence or Adjust Status | USCIS",
+      "page": "www.uscis.gov/i-485",
+      "linkUrl": "https://www.uscis.gov/sites/default/files/document/forms/i-485instr.pdf",
+      "total_events": "1840"
+    },
+    {
+      "page_title": "General Schedule",
+      "page": "www.opm.gov/policy-data-oversight/pay-leave/salaries-wages/2024/general-schedule",
+      "linkUrl": "https://www.opm.gov/policy-data-oversight/pay-leave/salaries-wages/salary-tables/24tables/pdf/dcb.pdf",
+      "total_events": "1760"
+    },
+    {
+      "page_title": "General Schedule",
+      "page": "www.opm.gov/policy-data-oversight/pay-leave/salaries-wages/2024/general-schedule/",
+      "linkUrl": "https://www.opm.gov/policy-data-oversight/pay-leave/salaries-wages/salary-tables/24tables/pdf/rus.pdf",
+      "total_events": "1727"
+    },
+    {
+      "page_title": "Premiums",
+      "page": "www.opm.gov/healthcare-insurance/healthcare/plan-information/premiums/",
+      "linkUrl": "https://www.opm.gov/healthcare-insurance/healthcare/plan-information/premiums/2025/fehb/2025-fehb-ffs-premium-rates.xlsx",
+      "total_events": "1718"
+    },
+    {
+      "page_title": "Premiums",
+      "page": "www.opm.gov/healthcare-insurance/healthcare/plan-information/premiums/",
+      "linkUrl": "https://www.opm.gov/healthcare-insurance/healthcare/plan-information/premiums/2025/fehb/2025-fehb-hmo-premium-rates.xlsx",
+      "total_events": "1694"
+    },
+    {
+      "page_title": "Military Compensation > Pay > Basic Pay > Active Duty Pay",
+      "page": "militarypay.defense.gov/pay/basic-pay/active-duty-pay/",
+      "linkUrl": "https://militarypay.defense.gov/portals/3/documents/activedutytables/2024 pay table-capped-final.pdf",
+      "total_events": "1581"
+    },
+    {
+      "page_title": "About Form 843, Claim for Refund and Request for Abatement | Internal Revenue Service",
+      "page": "www.irs.gov/forms-pubs/about-form-843",
+      "linkUrl": "https://www.irs.gov/pub/irs-pdf/f843.pdf",
+      "total_events": "1577"
+    },
+    {
+      "page_title": "Form MCS-150 and Instructions - Motor Carrier Identification Report | FMCSA",
+      "page": "www.fmcsa.dot.gov/registration/form-mcs-150-and-instructions-motor-carrier-identification-report",
+      "linkUrl": "https://www.fmcsa.dot.gov/sites/fmcsa.dot.gov/files/2024-04/mcs-150 form.pdf",
+      "total_events": "1563"
+    },
+    {
+      "page_title": "Housing Handbooks | HUD.gov / U.S. Department of Housing and Urban Development (HUD)",
+      "page": "www.hud.gov/program_offices/administration/hudclips/handbooks/hsgh",
+      "linkUrl": "https://www.hud.gov/sites/dfiles/ochco/documents/40001-hsgh-update15-052024.pdf",
+      "total_events": "1563"
+    },
+    {
+      "page_title": "Joint Typhoon Warning Center (JTWC)",
+      "page": "www.metoc.navy.mil/jtwc/jtwc.html",
+      "linkUrl": "https://www.metoc.navy.mil/jtwc/products/wp2224prog.txt",
+      "total_events": "1534"
+    },
+    {
+      "page_title": "CMS L564 | CMS",
+      "page": "www.cms.gov/medicare/cms-forms/cms-forms/cms-forms-items/cms009718",
+      "linkUrl": "https://www.cms.gov/medicare/cms-forms/cms-forms/downloads/cms-l564e.pdf",
+      "total_events": "1511"
+    },
+    {
+      "page_title": "Army Publishing Directorate",
+      "page": "armypubs.army.mil/productmaps/pubform/details.aspx",
+      "linkUrl": "https://armypubs.army.mil/pub/eforms/dr_a/arn39139-da_form_4856-001-efile-2.pdf",
+      "total_events": "1506"
+    },
+    {
+      "page_title": "About Form 8822-B, Change of Address or Responsible Party - Business | Internal Revenue Service",
+      "page": "www.irs.gov/forms-pubs/about-form-8822-b",
+      "linkUrl": "https://www.irs.gov/pub/irs-pdf/f8822b.pdf",
+      "total_events": "1468"
+    },
+    {
+      "page_title": "About Form SS-4, Application for Employer Identification Number (EIN) | Internal Revenue Service",
+      "page": "www.irs.gov/forms-pubs/about-form-ss-4",
+      "linkUrl": "https://www.irs.gov/pub/irs-pdf/fss4.pdf",
+      "total_events": "1454"
+    },
+    {
+      "page_title": "“Lotería de visas”: averigüe si es elegible y cómo participar | USAGov",
+      "page": "www.usa.gov/es/participar-loteria-visas",
+      "linkUrl": "https://travel.state.gov/content/dam/visas/diversity-visa/dv-instructions-translations/dv-2026-instructions-translations/dv 2026 plain language instructions and faqs.pdf",
+      "total_events": "1421"
+    },
+    {
+      "page_title": "Authorization for Credit Card Transactions | USCIS",
+      "page": "www.uscis.gov/g-1450",
+      "linkUrl": "https://www.uscis.gov/sites/default/files/document/forms/g-1450.pdf",
+      "total_events": "1407"
+    },
+    {
+      "page_title": "Forms & instructions | Internal Revenue Service",
+      "page": "www.irs.gov/forms-instructions",
+      "linkUrl": "https://www.irs.gov/pub/irs-pdf/f1040.pdf",
+      "total_events": "1403"
+    },
+    {
+      "page_title": "General Schedule",
+      "page": "www.opm.gov/policy-data-oversight/pay-leave/salaries-wages/2024/general-schedule",
+      "linkUrl": "https://www.opm.gov/policy-data-oversight/pay-leave/salaries-wages/salary-tables/24tables/pdf/gs.pdf",
+      "total_events": "1398"
+    },
+    {
+      "page_title": "About Form W-8 BEN, Certificate of Foreign Status of Beneficial Owner for United States Tax Withholding and Reporting (Individuals) | Internal Revenue Service",
+      "page": "www.irs.gov/forms-pubs/about-form-w-8-ben",
+      "linkUrl": "https://www.irs.gov/pub/irs-pdf/fw8ben.pdf",
+      "total_events": "1379"
+    },
+    {
+      "page_title": "Petition to Remove Conditions on Residence | USCIS",
+      "page": "www.uscis.gov/i-751",
+      "linkUrl": "https://www.uscis.gov/sites/default/files/document/forms/i-751.pdf",
+      "total_events": "1370"
+    },
+    {
+      "page_title": "Petition for Alien Fiancé(e) | USCIS",
+      "page": "www.uscis.gov/i-129f",
+      "linkUrl": "https://www.uscis.gov/sites/default/files/document/forms/i-129f.pdf",
+      "total_events": "1365"
+    },
+    {
+      "page_title": "Request Pertaining to Military Records | GSA",
+      "page": "www.gsa.gov/reference/forms/request-pertaining-to-military-records",
+      "linkUrl": "https://www.gsa.gov/system/files/2024-10/sf180-24a.pdf",
+      "total_events": "1365"
+    },
+    {
+      "page_title": "FMLA: Forms | U.S. Department of Labor",
+      "page": "www.dol.gov/agencies/whd/fmla/forms",
+      "linkUrl": "https://www.dol.gov/sites/dolgov/files/whd/legacy/files/wh-381.pdf",
+      "total_events": "1360"
+    },
+    {
+      "page_title": "About Form W-8 IMY, Certificate of Foreign Intermediary, Foreign Flow-Through Entity, or Certain U.S. Branches for United States Tax Withholding and Reporting | Internal Revenue Service",
+      "page": "www.irs.gov/forms-pubs/about-form-w-8-imy",
+      "linkUrl": "https://www.irs.gov/pub/irs-pdf/fw8imy.pdf",
+      "total_events": "1355"
+    },
+    {
+      "page_title": "Application for Employment Authorization | USCIS",
+      "page": "www.uscis.gov/i-765",
+      "linkUrl": "https://www.uscis.gov/sites/default/files/document/forms/i-765instr.pdf",
+      "total_events": "1355"
+    },
+    {
+      "page_title": "Apply for a Child's U.S. Passport",
+      "page": "travel.state.gov/content/travel/en/passports/need-passport/under-16.html",
+      "linkUrl": "https://eforms.state.gov/forms/ds3053.pdf",
+      "total_events": "1351"
+    },
+    {
+      "page_title": "Federal Student Aid",
+      "page": "studentaid.gov/manage-loans/forgiveness-cancellation/public-service/public-service-loan-forgiveness-application",
+      "linkUrl": "https://studentaid.gov/sites/default/files/public-service-application-for-forgiveness.pdf",
+      "total_events": "1341"
+    },
+    {
+      "page_title": "MPDG FY 2025-2026 INFRA Awards | US Department of Transportation",
+      "page": "www.transportation.gov/grants/mpdg-program/mpdgfy25-26/infra-awards",
+      "linkUrl": "https://www.transportation.gov/sites/dot.gov/files/2024-10/mpdg 25-26 infra fact sheets final_0.pdf",
+      "total_events": "1337"
+    },
+    {
+      "page_title": "Medicare & You | Medicare",
+      "page": "www.medicare.gov/medicare-and-you",
+      "linkUrl": "https://www.medicare.gov/publications/10050-medicare-and-you.pdf",
+      "total_events": "1327"
+    },
+    {
+      "page_title": "Premiums",
+      "page": "www.opm.gov/healthcare-insurance/healthcare/plan-information/premiums/",
+      "linkUrl": "https://www.opm.gov/healthcare-insurance/healthcare/plan-information/premiums/2025/pshb/2025-pshb-ffs-premium-rates.xlsx",
+      "total_events": "1323"
+    },
+    {
+      "page_title": "ALEXIS FLORES — FBI",
+      "page": "www.fbi.gov/wanted/topten/alexis-flores",
+      "linkUrl": "https://www.fbi.gov/wanted/topten/alexis-flores/@@download.pdf",
+      "total_events": "1308"
+    },
+    {
+      "page_title": "Latest Satellite Imagery",
+      "page": "www.nhc.noaa.gov/satellite.php",
+      "linkUrl": "https://cdn.star.nesdis.noaa.gov/goes16/abi/sector/taw/13/1800x1080.jpg",
+      "total_events": "1290"
+    },
+    {
+      "page_title": "Your child needs vaccines as they grow! | Vaccines & Immunizations | CDC",
+      "page": "www.cdc.gov/vaccines/imz-schedules/child-easyread.html",
+      "linkUrl": "https://www.cdc.gov/vaccines/imz-schedules/downloads/parent-ver-sch-0-6yrs.pdf",
+      "total_events": "1290"
+    },
+    {
+      "page_title": "ASP Pricing Files | CMS",
+      "page": "www.cms.gov/medicare/payment/part-b-drugs/asp-pricing-files",
+      "linkUrl": "https://www.cms.gov/files/zip/october-2024-asp-pricing-file.zip",
+      "total_events": "1285"
+    },
+    {
+      "page_title": "General Schedule",
+      "page": "www.opm.gov/policy-data-oversight/pay-leave/salaries-wages/2024/general-schedule/",
+      "linkUrl": "https://www.opm.gov/policy-data-oversight/pay-leave/salaries-wages/salary-tables/24tables/pdf/gs.pdf",
+      "total_events": "1271"
+    },
+    {
+      "page_title": "Premiums",
+      "page": "www.opm.gov/healthcare-insurance/healthcare/plan-information/premiums/",
+      "linkUrl": "https://www.opm.gov/healthcare-insurance/healthcare/plan-information/premiums/2025/fehb/2025-spo-vs-sf-fehb.xlsx",
+      "total_events": "1261"
+    },
+    {
+      "page_title": "Vaccine Information Statement | Tdap | Tetanus-Diphtheria-Pertussis | VIS | CDC",
+      "page": "www.cdc.gov/vaccines/hcp/vis/vis-statements/tdap.html",
+      "linkUrl": "https://www.cdc.gov/vaccines/hcp/vis/vis-statements/tdap.pdf",
+      "total_events": "1261"
+    },
+    {
+      "page_title": "Immigrant Petition for Alien Workers | USCIS",
+      "page": "www.uscis.gov/i-140",
+      "linkUrl": "https://www.uscis.gov/sites/default/files/document/forms/i-140.pdf",
+      "total_events": "1257"
+    },
+    {
+      "page_title": "Diversity Visa Instructions",
+      "page": "travel.state.gov/content/travel/en/us-visas/immigrate/diversity-visa-program-entry/diversity-visa-instructions.html",
+      "linkUrl": "https://travel.state.gov/content/dam/visas/diversity-visa/dv-instructions-translations/dv-2026-instructions-translations/dv_2026_instructions_ukr.pdf",
+      "total_events": "1252"
+    },
+    {
+      "page_title": "About Form W-7, Application for IRS Individual Taxpayer Identification Number | Internal Revenue Service",
+      "page": "www.irs.gov/forms-pubs/about-form-w-7",
+      "linkUrl": "https://www.irs.gov/pub/irs-pdf/fw7.pdf",
+      "total_events": "1238"
+    },
+    {
+      "page_title": "Site Index Search | Internal Revenue Service",
+      "page": "www.irs.gov/site-index-search?query=941",
+      "linkUrl": "https://www.irs.gov/pub/irs-pdf/f941.pdf",
+      "total_events": "1228"
+    },
+    {
+      "page_title": "Affidavit of Support Under Section 213A of the INA | USCIS",
+      "page": "www.uscis.gov/i-864",
+      "linkUrl": "https://www.uscis.gov/sites/default/files/document/forms/i-864instr.pdf",
+      "total_events": "1205"
+    },
+    {
+      "page_title": "MPDG FY 2025-2026 Mega Awards | US Department of Transportation",
+      "page": "www.transportation.gov/grants/mpdg-program/mpdgfy25-26/mega-awards",
+      "linkUrl": "https://www.transportation.gov/sites/dot.gov/files/2024-10/mpdg 25-26 mega fact sheets final.pdf",
+      "total_events": "1205"
+    },
+    {
+      "page_title": "About Form 1040-ES, Estimated Tax for Individuals | Internal Revenue Service",
+      "page": "www.irs.gov/forms-pubs/about-form-1040-es",
+      "linkUrl": "https://www.irs.gov/pub/irs-pdf/f1040es.pdf",
+      "total_events": "1191"
+    },
+    {
+      "page_title": "FMLA: Forms | U.S. Department of Labor",
+      "page": "www.dol.gov/agencies/whd/fmla/forms",
+      "linkUrl": "https://www.dol.gov/sites/dolgov/files/whd/legacy/files/wh-380-f.pdf",
+      "total_events": "1167"
+    },
+    {
+      "page_title": "COVID-19 Vaccine Information Statement | CDC",
+      "page": "www.cdc.gov/vaccines/hcp/vis/vis-statements/covid-19.html",
+      "linkUrl": "https://www.cdc.gov/vaccines/hcp/vis/vis-statements/covid-19.pdf",
+      "total_events": "1162"
     },
     {
       "page_title": "Schedule of Social Security Payments | SSA",
-      "event_label": "file_download",
-      "file_name": "/pubs/en-05-10031-2024.pdf",
       "page": "www.ssa.gov/pubs/calendar.htm",
-      "total_events": "524"
+      "linkUrl": "https://www.ssa.gov/pubs/en-05-10031-2024.pdf",
+      "total_events": "1158"
+    },
+    {
+      "page_title": "USDA Food Plans: Monthly Cost of Food Reports | Food and Nutrition Service",
+      "page": "www.fns.usda.gov/cnpp/usda-food-plans-cost-food-monthly-reports",
+      "linkUrl": "https://www.fns.usda.gov/sites/default/files/resource-files/cost_of_food_low_moderate_liberal_food_plans_august_2024.pdf",
+      "total_events": "1144"
+    },
+    {
+      "page_title": "About Form 1099-MISC, Miscellaneous Information | Internal Revenue Service",
+      "page": "www.irs.gov/forms-pubs/about-form-1099-misc",
+      "linkUrl": "https://www.irs.gov/pub/irs-pdf/f1099msc.pdf",
+      "total_events": "1139"
     }
   ],
   "totals": {
-    "total_events": 165253
+    "total_events": 303299
   },
-  "taken_at": "2024-10-21T14:40:33.108Z"
+  "taken_at": "2024-10-22T19:07:23.141Z"
 }

--- a/ga4-data/live/top-downloads-yesterday.json
+++ b/ga4-data/live/top-downloads-yesterday.json
@@ -1,10 +1,34 @@
 {
   "name": "top-downloads-yesterday",
+  "agency": null,
+  "sampling": [
+    {
+      "samplesReadCount": "99665609",
+      "samplingSpaceSize": "263594790"
+    }
+  ],
   "query": {
-    "dimensions": [
+    "limit": "100",
+    "metrics": [
       {
-        "name": "date"
-      },
+        "name": "eventCount"
+      }
+    ],
+    "orderBys": [
+      {
+        "desc": true,
+        "metric": {
+          "metricName": "eventCount"
+        }
+      }
+    ],
+    "dateRanges": [
+      {
+        "endDate": "yesterday",
+        "startDate": "yesterday"
+      }
+    ],
+    "dimensions": [
       {
         "name": "pageTitle"
       },
@@ -18,31 +42,12 @@
         "name": "fullPageUrl"
       }
     ],
-    "metrics": [
-      {
-        "name": "eventCount"
-      }
-    ],
-    "dateRanges": [
-      {
-        "startDate": "yesterday",
-        "endDate": "yesterday"
-      }
-    ],
-    "orderBys": [
-      {
-        "metric": {
-          "metricName": "eventCount"
-        },
-        "desc": true
-      }
-    ],
     "dimensionFilter": {
       "filter": {
         "fieldName": "eventName",
         "stringFilter": {
-          "matchType": "FULL_REGEXP",
           "value": "^(file_download|download|downloads|(outbound downloads))$",
+          "matchType": "FULL_REGEXP",
           "caseSensitive": false
         }
       },
@@ -53,8 +58,8 @@
               "filter": {
                 "fieldName": "fileName",
                 "stringFilter": {
-                  "matchType": "PARTIAL_REGEXP",
                   "value": ".*\\\\.(zip|doc)\\b.*",
+                  "matchType": "PARTIAL_REGEXP",
                   "caseSensitive": false
                 }
               }
@@ -65,8 +70,8 @@
               "filter": {
                 "fieldName": "fullPageUrl",
                 "stringFilter": {
-                  "matchType": "PARTIAL_REGEXP",
                   "value": ".*\\busps\\.com\\b.*",
+                  "matchType": "PARTIAL_REGEXP",
                   "caseSensitive": false
                 }
               }
@@ -75,824 +80,716 @@
         ]
       }
     },
-    "limit": "100",
-    "samplingLevel": "HIGHER_PRECISION",
-    "property": "properties/393249053"
+    "property": "properties/397708109"
   },
   "meta": {
     "name": "Top Downloads Yesterday",
-    "description": "Top downloads yesterday"
+    "description": "Top 100 downloads yesterday"
   },
   "data": [
     {
-      "date": "2024-01-04",
-      "page_title": "Inactivated Influenza Vaccine Information Statement | CDC",
+      "page_title": "Diversity Visa Instructions",
       "event_label": "file_download",
-      "file_name": "https://www.cdc.gov/vaccines/hcp/vis/vis-statements/flu.pdf",
-      "page": "www.cdc.gov/vaccines/hcp/vis/vis-statements/flu.html",
-      "total_events": "30000000"
+      "file_name": "/content/dam/visas/diversity-visa/dv-instructions-translations/dv-2026-instructions-translations/dv 2026 plain language instructions and faqs.pdf",
+      "page": "travel.state.gov/content/travel/en/us-visas/immigrate/diversity-visa-program-entry/diversity-visa-instructions.html",
+      "total_events": "17358"
     },
     {
-      "date": "2024-01-04",
-      "page_title": "About Form W-9, Request for Taxpayer Identification Number and Certification | Internal Revenue Service",
+      "page_title": "Diversity Visa Instructions",
       "event_label": "file_download",
-      "file_name": "/pub/irs-pdf/fw9.pdf",
-      "page": "www.irs.gov/forms-pubs/about-form-w-9",
-      "total_events": "28634"
+      "file_name": "/content/dam/visas/diversity-visa/dv-instructions-translations/dv-2025-instructions-translations/dv-2025-instructions.pdf",
+      "page": "travel.state.gov/content/travel/en/us-visas/immigrate/diversity-visa-program-entry/diversity-visa-instructions.html",
+      "total_events": "16392"
     },
     {
-      "date": "2024-01-04",
-      "page_title": "Small Entity Compliance Guide | FinCEN.gov",
+      "page_title": "BrucePac Recalls Ready-To-Eat Meat and Poultry Products Due to Possible Listeria Contamination | Food Safety and Inspection Service",
       "event_label": "file_download",
-      "file_name": "/sites/default/files/shared/boi_small_compliance_guide.v1.1-final.pdf",
-      "page": "www.fincen.gov/boi/small-entity-compliance-guide",
-      "total_events": "9426"
+      "file_name": "/sites/default/files/food_label_pdf/2024-10/recall-028-2024-labels.pdf",
+      "page": "www.fsis.usda.gov/recalls-alerts/brucepac-recalls-ready-eat-meat-and-poultry-products-due-possible-listeria",
+      "total_events": "15038"
     },
     {
-      "date": "2024-01-04",
-      "page_title": "Passport Fees",
+      "page_title": "Mars Science Laboratory: Curiosity Rover - NASA Science",
       "event_label": "file_download",
-      "file_name": "/content/dam/passports/forms-fees/fee%20chart%202023.pdf",
-      "page": "travel.state.gov/content/travel/en/passports/how-apply/fees.html",
-      "total_events": "9295"
+      "file_name": "/wp-content/uploads/2024/04/msl-sci-team-key-papers-sept-20-2024.pdf",
+      "page": "science.nasa.gov/mission/msl-curiosity/",
+      "total_events": "5549"
     },
     {
-      "date": "2024-01-04",
-      "page_title": "Employment Eligibility Verification | USCIS",
+      "page_title": "BOI E-FILING",
       "event_label": "file_download",
-      "file_name": "/sites/default/files/document/forms/i-9.pdf",
-      "page": "www.uscis.gov/i-9",
-      "total_events": "8984"
+      "file_name": "/c8576e94532490750200.pdf",
+      "page": "boiefiling.fincen.gov/",
+      "total_events": "4290"
     },
     {
-      "date": "2024-01-04",
-      "page_title": "General Schedule",
+      "page_title": "BrucePac Recalls Ready-To-Eat Meat and Poultry Products Due to Possible Listeria Contamination | Food Safety and Inspection Service",
       "event_label": "file_download",
-      "file_name": "/policy-data-oversight/pay-leave/salaries-wages/salary-tables/24tables/pdf/dcb.pdf",
-      "page": "www.opm.gov/policy-data-oversight/pay-leave/salaries-wages/2024/general-schedule",
-      "total_events": "8774"
+      "file_name": "/sites/default/files/distro_list/2024-10/rc-028-2024-retail-list.pdf",
+      "page": "www.fsis.usda.gov/recalls-alerts/brucepac-recalls-ready-eat-meat-and-poultry-products-due-possible-listeria",
+      "total_events": "3822"
     },
     {
-      "date": "2024-01-04",
-      "page_title": "General Schedule",
-      "event_label": "file_download",
-      "file_name": "/policy-data-oversight/pay-leave/salaries-wages/salary-tables/24tables/pdf/rus.pdf",
-      "page": "www.opm.gov/policy-data-oversight/pay-leave/salaries-wages/2024/general-schedule",
-      "total_events": "8174"
-    },
-    {
-      "date": "2024-01-04",
-      "page_title": "About Form W-4, Employee's Withholding Certificate | Internal Revenue Service",
-      "event_label": "file_download",
-      "file_name": "/pub/irs-pdf/fw4.pdf",
-      "page": "www.irs.gov/forms-pubs/about-form-w-4",
-      "total_events": "6385"
-    },
-    {
-      "date": "2024-01-04",
-      "page_title": "Tax Withholding | Internal Revenue Service",
-      "event_label": "file_download",
-      "file_name": "/pub/irs-pdf/n1036.pdf",
-      "page": "www.irs.gov/payments/tax-withholding",
-      "total_events": "6312"
-    },
-    {
-      "date": "2024-01-04",
-      "page_title": "Replace Social Security card | SSA",
-      "event_label": "file_download",
-      "file_name": "/forms/ss-5.pdf",
-      "page": "www.ssa.gov/number-card/replace-card",
-      "total_events": "5942"
-    },
-    {
-      "date": "2024-01-04",
-      "page_title": "About Form 1040, U.S. Individual Income Tax Return | Internal Revenue Service",
-      "event_label": "file_download",
-      "file_name": "/pub/irs-pdf/f1040.pdf",
-      "page": "www.irs.gov/forms-pubs/about-form-1040",
-      "total_events": "5545"
-    },
-    {
-      "date": "2024-01-04",
-      "page_title": "Forms & Instructions | Internal Revenue Service",
-      "event_label": "file_download",
-      "file_name": "/pub/irs-pdf/f1040.pdf",
-      "page": "www.irs.gov/forms-instructions",
-      "total_events": "5052"
-    },
-    {
-      "date": "2024-01-04",
       "page_title": "Affidavit of Support Under Section 213A of the INA | USCIS",
       "event_label": "file_download",
       "file_name": "/sites/default/files/document/forms/i-864.pdf",
       "page": "www.uscis.gov/i-864",
-      "total_events": "4976"
+      "total_events": "3335"
     },
     {
-      "date": "2024-01-04",
-      "page_title": "FMLA: Forms | U.S. Department of Labor",
+      "page_title": "BrucePac Recalls Ready-To-Eat Meat and Poultry Products Due to Possible Listeria Contamination | Food Safety and Inspection Service",
       "event_label": "file_download",
-      "file_name": "/sites/dolgov/files/whd/legacy/files/wh-380-e.pdf",
-      "page": "www.dol.gov/agencies/whd/fmla/forms",
-      "total_events": "4954"
+      "file_name": "/sites/default/files/distro_list/2024-10/rc-028-2024-school_distribution_list.pdf",
+      "page": "www.fsis.usda.gov/recalls-alerts/brucepac-recalls-ready-eat-meat-and-poultry-products-due-possible-listeria",
+      "total_events": "3084"
     },
     {
-      "date": "2024-01-04",
-      "page_title": "About Form 1099-NEC, Nonemployee Compensation | Internal Revenue Service",
+      "page_title": "Employment Eligibility Verification | USCIS",
       "event_label": "file_download",
-      "file_name": "/pub/irs-pdf/f1099nec.pdf",
-      "page": "www.irs.gov/forms-pubs/about-form-1099-nec",
-      "total_events": "4926"
+      "file_name": "/sites/default/files/document/forms/i-9.pdf",
+      "page": "www.uscis.gov/i-9",
+      "total_events": "2716"
     },
     {
-      "date": "2024-01-04",
-      "page_title": "About Form W-2, Wage and Tax Statement | Internal Revenue Service",
-      "event_label": "file_download",
-      "file_name": "/pub/irs-pdf/fw2.pdf",
-      "page": "www.irs.gov/forms-pubs/about-form-w-2",
-      "total_events": "4892"
-    },
-    {
-      "date": "2024-01-04",
-      "page_title": "Forms & Instructions | Internal Revenue Service",
-      "event_label": "file_download",
-      "file_name": "/pub/irs-pdf/i1040gi.pdf",
-      "page": "www.irs.gov/forms-instructions",
-      "total_events": "4559"
-    },
-    {
-      "date": "2024-01-04",
-      "page_title": "Renew my Passport by Mail",
-      "event_label": "file_download",
-      "file_name": "/forms/ds82.pdf",
-      "page": "travel.state.gov/content/travel/en/passports/have-passport/renew.html",
-      "total_events": "4486"
-    },
-    {
-      "date": "2024-01-04",
-      "page_title": "How to Apply in Person for a Passport",
-      "event_label": "file_download",
-      "file_name": "/forms/ds11.pdf",
-      "page": "travel.state.gov/content/travel/en/passports/need-passport/apply-in-person.html",
-      "total_events": "4254"
-    },
-    {
-      "date": "2024-01-04",
-      "page_title": "Beneficial Ownership Information Reporting | FinCEN.gov",
-      "event_label": "file_download",
-      "file_name": "/sites/default/files/shared/boi%20informational%20brochure%20508c.pdf",
-      "page": "www.fincen.gov/boi",
-      "total_events": "4075"
-    },
-    {
-      "date": "2024-01-04",
-      "page_title": "About Form 1099-MISC, Miscellaneous Information | Internal Revenue Service",
-      "event_label": "file_download",
-      "file_name": "/pub/irs-pdf/f1099msc.pdf",
-      "page": "www.irs.gov/forms-pubs/about-form-1099-misc",
-      "total_events": "3996"
-    },
-    {
-      "date": "2024-01-04",
-      "page_title": "General Schedule",
-      "event_label": "file_download",
-      "file_name": "/policy-data-oversight/pay-leave/salaries-wages/salary-tables/24tables/pdf/gs.pdf",
-      "page": "www.opm.gov/policy-data-oversight/pay-leave/salaries-wages/2024/general-schedule",
-      "total_events": "3929"
-    },
-    {
-      "date": "2024-01-04",
-      "page_title": "Application for Employment Authorization | USCIS",
-      "event_label": "file_download",
-      "file_name": "/sites/default/files/document/forms/i-765.pdf",
-      "page": "www.uscis.gov/i-765",
-      "total_events": "3909"
-    },
-    {
-      "date": "2024-01-04",
       "page_title": "Application to Register Permanent Residence or Adjust Status | USCIS",
       "event_label": "file_download",
       "file_name": "/sites/default/files/document/forms/i-485.pdf",
       "page": "www.uscis.gov/i-485",
-      "total_events": "3828"
+      "total_events": "2645"
     },
     {
-      "date": "2024-01-04",
-      "page_title": "Recordkeeping - Recordkeeping Forms | Occupational Safety and Health Administration",
+      "page_title": "Diversity Visa Instructions",
       "event_label": "file_download",
-      "file_name": "/sites/default/files/osha-rk-forms-package.pdf",
-      "page": "www.osha.gov/recordkeeping/forms",
-      "total_events": "3722"
+      "file_name": "/content/dam/visas/diversity-visa/dv-instructions-translations/dv-2026-instructions-translations/dv-2026 how_to_apply_infographic.pdf",
+      "page": "travel.state.gov/content/travel/en/us-visas/immigrate/diversity-visa-program-entry/diversity-visa-instructions.html",
+      "total_events": "2483"
     },
     {
-      "date": "2024-01-04",
-      "page_title": "Boston/Norton, MA Weather Forecast Office Winter Weather Forecasts",
+      "page_title": "Replace Social Security card | SSA",
       "event_label": "file_download",
-      "file_name": "/images/box/winter/stormtotalsnowweb.jpg",
-      "page": "www.weather.gov/box/winter",
-      "total_events": "3573"
+      "file_name": "/forms/ss-5.pdf",
+      "page": "www.ssa.gov/number-card/replace-card",
+      "total_events": "2457"
     },
     {
-      "date": "2024-01-04",
-      "page_title": "Apply for a Child's U.S. Passport",
-      "event_label": "file_download",
-      "file_name": "/forms/ds11.pdf",
-      "page": "travel.state.gov/content/travel/en/passports/need-passport/under-16.html",
-      "total_events": "3568"
-    },
-    {
-      "date": "2024-01-04",
       "page_title": "Petition for Alien Relative | USCIS",
       "event_label": "file_download",
       "file_name": "/sites/default/files/document/forms/i-130.pdf",
       "page": "www.uscis.gov/i-130",
-      "total_events": "2977"
+      "total_events": "2153"
     },
     {
-      "date": "2024-01-04",
-      "page_title": "Change name with Social Security | SSA",
-      "event_label": "file_download",
-      "file_name": "/forms/ss-5.pdf",
-      "page": "www.ssa.gov/personal-record/change-name",
-      "total_events": "2932"
-    },
-    {
-      "date": "2024-01-04",
-      "page_title": "About Form W-4V, Voluntary Withholding Request | Internal Revenue Service",
-      "event_label": "file_download",
-      "file_name": "/pub/irs-pdf/fw4v.pdf",
-      "page": "www.irs.gov/forms-pubs/about-form-w-4-v",
-      "total_events": "2924"
-    },
-    {
-      "date": "2024-01-04",
-      "page_title": "Astronomy Picture of the Day",
-      "event_label": "file_download",
-      "file_name": "/apod/image/2401/zetaoph_spitzer_4015.jpg",
-      "page": "apod.nasa.gov/apod/astropix.html",
-      "total_events": "2722"
-    },
-    {
-      "date": "2024-01-04",
-      "page_title": "FMLA: Forms | U.S. Department of Labor",
-      "event_label": "file_download",
-      "file_name": "/sites/dolgov/files/whd/legacy/files/wh-380-f.pdf",
-      "page": "www.dol.gov/agencies/whd/fmla/forms",
-      "total_events": "2658"
-    },
-    {
-      "date": "2024-01-04",
-      "page_title": "About Form 941, Employer's Quarterly Federal Tax Return | Internal Revenue Service",
-      "event_label": "file_download",
-      "file_name": "/pub/irs-pdf/f941.pdf",
-      "page": "www.irs.gov/forms-pubs/about-form-941",
-      "total_events": "2627"
-    },
-    {
-      "date": "2024-01-04",
-      "page_title": "Boston/Norton, MA Weather Forecast Office Winter Weather Forecasts",
-      "event_label": "file_download",
-      "file_name": "/images/box/winter/snowamt90prcntl.jpg",
-      "page": "www.weather.gov/box/winter",
-      "total_events": "2557"
-    },
-    {
-      "date": "2024-01-04",
-      "page_title": "Replacement Card",
-      "event_label": "file_download",
-      "file_name": "/forms/ss-5.pdf",
-      "page": "www.ssa.gov/number-card/replace-card/get-started/applicant",
-      "total_events": "2532"
-    },
-    {
-      "date": "2024-01-04",
-      "page_title": "About Form 1040-ES, Estimated Tax for Individuals | Internal Revenue Service",
-      "event_label": "file_download",
-      "file_name": "/pub/irs-pdf/f1040es.pdf",
-      "page": "www.irs.gov/forms-pubs/about-form-1040-es",
-      "total_events": "2520"
-    },
-    {
-      "date": "2024-01-04",
       "page_title": "Army Publishing Directorate",
       "event_label": "file_download",
       "file_name": "/pub/eforms/dr_a/arn39139-da_form_4856-001-efile-2.pdf",
-      "page": "armypubs.army.mil/ProductMaps/PubForm/Details.aspx",
-      "total_events": "2372"
+      "page": "armypubs.army.mil/productmaps/pubform/details.aspx",
+      "total_events": "2044"
     },
     {
-      "date": "2024-01-04",
-      "page_title": "IRIS Application for TCC | Internal Revenue Service",
+      "page_title": "Find out if you are eligible for the Diversity Visa (DV) Lottery and how to register | USAGov",
       "event_label": "file_download",
-      "file_name": "/pub/taxpros/irs-application-for-tcc-tutorial-1.pdf",
-      "page": "www.irs.gov/tax-professionals/iris-application-for-tcc",
-      "total_events": "2333"
+      "file_name": "/content/dam/visas/diversity-visa/dv-instructions-translations/dv-2026-instructions-translations/dv 2026 plain language instructions and faqs.pdf",
+      "page": "www.usa.gov/dv-lottery-eligibility",
+      "total_events": "2034"
     },
     {
-      "date": "2024-01-04",
-      "page_title": "Snow and Ice Forecasts & Services",
+      "page_title": "Astronomy Picture of the Day",
       "event_label": "file_download",
-      "file_name": "/images/lwx/winter/stormtotalsnowweb1.jpg",
-      "page": "www.weather.gov/lwx/winter",
-      "total_events": "2252"
+      "file_name": "/apod/image/2410/darkmatter_kipacamnh_1200.jpg",
+      "page": "apod.nasa.gov/apod/astropix.html",
+      "total_events": "1965"
     },
     {
-      "date": "2024-01-04",
-      "page_title": "Forms & Instructions | Internal Revenue Service",
+      "page_title": "Passport Forms",
       "event_label": "file_download",
-      "file_name": "/pub/irs-pdf/i1040tt.pdf",
-      "page": "www.irs.gov/forms-instructions",
-      "total_events": "2156"
+      "file_name": "/forms/ds11_pdf.pdf",
+      "page": "travel.state.gov/content/travel/en/passports/how-apply/forms.html",
+      "total_events": "1915"
     },
     {
-      "date": "2024-01-04",
-      "page_title": "FMLA: Forms | U.S. Department of Labor",
+      "page_title": "Fee Schedule | USCIS",
       "event_label": "file_download",
-      "file_name": "/sites/dolgov/files/whd/legacy/files/wh-381.pdf",
-      "page": "www.dol.gov/agencies/whd/fmla/forms",
-      "total_events": "2142"
+      "file_name": "/sites/default/files/document/forms/g-1055.pdf",
+      "page": "www.uscis.gov/g-1055",
+      "total_events": "1912"
     },
     {
-      "date": "2024-01-04",
-      "page_title": "Fratelli Beretta USA, Inc. Recalls Busseto Foods Brand Ready-to-Eat Charcuterie Meat Products Due to Possible Salmonella Contamination | Food Safety and Inspection Service",
+      "page_title": "Application for Employment Authorization | USCIS",
       "event_label": "file_download",
-      "file_name": "/sites/default/files/food_label_pdf/2024-01/recall-001-2024-labels.pdf",
-      "page": "www.fsis.usda.gov/recalls-alerts/fratelli-beretta-usa-inc--recalls-busseto-foods-brand-ready-eat-charcuterie-meat",
-      "total_events": "2117"
-    },
-    {
-      "date": "2024-01-04",
-      "page_title": "Applicable Federal Rates | Internal Revenue Service",
-      "event_label": "file_download",
-      "file_name": "/pub/irs-drop/rr-24-02.pdf",
-      "page": "www.irs.gov/applicable-federal-rates",
-      "total_events": "2100"
-    },
-    {
-      "date": "2024-01-04",
-      "page_title": "Snow and Ice Forecasts & Services",
-      "event_label": "file_download",
-      "file_name": "/images/lwx/winter/snowamt90prcntl.jpg",
-      "page": "www.weather.gov/lwx/winter",
-      "total_events": "2086"
-    },
-    {
-      "date": "2024-01-04",
-      "page_title": "Employment Eligibility Verification | USCIS",
-      "event_label": "file_download",
-      "file_name": "/sites/default/files/document/forms/i-9instr.pdf",
-      "page": "www.uscis.gov/i-9",
-      "total_events": "2083"
-    },
-    {
-      "date": "2024-01-04",
-      "page_title": "Recordkeeping - Recordkeeping Forms | Occupational Safety and Health Administration",
-      "event_label": "file_download",
-      "file_name": "/sites/default/files/new-osha300form.xlsx",
-      "page": "www.osha.gov/recordkeeping/forms",
-      "total_events": "2072"
-    },
-    {
-      "date": "2024-01-04",
-      "page_title": "Alien’s Change of Address Card | USCIS",
-      "event_label": "file_download",
-      "file_name": "/sites/default/files/document/forms/ar-11.pdf",
-      "page": "www.uscis.gov/ar-11",
-      "total_events": "2058"
-    },
-    {
-      "date": "2024-01-04",
-      "page_title": "About Schedule A (Form 1040), Itemized Deductions | Internal Revenue Service",
-      "event_label": "file_download",
-      "file_name": "/pub/irs-pdf/f1040sa.pdf",
-      "page": "www.irs.gov/forms-pubs/about-schedule-a-form-1040",
-      "total_events": "1952"
-    },
-    {
-      "date": "2024-01-04",
-      "page_title": "Application for Naturalization | USCIS",
-      "event_label": "file_download",
-      "file_name": "/sites/default/files/document/forms/n-400.pdf",
-      "page": "www.uscis.gov/n-400",
-      "total_events": "1943"
-    },
-    {
-      "date": "2024-01-04",
-      "page_title": "About Form 4506-T, Request for Transcript of Tax Return | Internal Revenue Service",
-      "event_label": "file_download",
-      "file_name": "/pub/irs-pdf/f4506t.pdf",
-      "page": "www.irs.gov/forms-pubs/about-form-4506-t",
-      "total_events": "1904"
-    },
-    {
-      "date": "2024-01-04",
-      "page_title": "Payroll Calendars | GSA",
-      "event_label": "file_download",
-      "file_name": "/system/files/2024_gsa_payroll_calendar.pdf",
-      "page": "www.gsa.gov/buy-through-us/purchasing-programs/shared-services/payroll-shared-services/payroll-calendars",
-      "total_events": "1865"
-    },
-    {
-      "date": "2024-01-04",
-      "page_title": "Application to Replace Permanent Resident Card (Green Card) | USCIS",
-      "event_label": "file_download",
-      "file_name": "/sites/default/files/document/forms/i-90.pdf",
-      "page": "www.uscis.gov/i-90",
-      "total_events": "1840"
-    },
-    {
-      "date": "2024-01-04",
-      "page_title": "About Form 940, Employer's Annual Federal Unemployment (FUTA) Tax Return | Internal Revenue Service",
-      "event_label": "file_download",
-      "file_name": "/pub/irs-pdf/f940.pdf",
-      "page": "www.irs.gov/forms-pubs/about-form-940",
+      "file_name": "/sites/default/files/document/forms/i-765.pdf",
+      "page": "www.uscis.gov/i-765",
       "total_events": "1809"
     },
     {
-      "date": "2024-01-04",
-      "page_title": "General Schedule",
-      "event_label": "file_download",
-      "file_name": "/policy-data-oversight/pay-leave/salaries-wages/salary-tables/24tables/pdf/rus_h.pdf",
-      "page": "www.opm.gov/policy-data-oversight/pay-leave/salaries-wages/2024/general-schedule",
-      "total_events": "1787"
-    },
-    {
-      "date": "2024-01-04",
       "page_title": "Request for Fee Waiver | USCIS",
       "event_label": "file_download",
       "file_name": "/sites/default/files/document/forms/i-912.pdf",
       "page": "www.uscis.gov/i-912",
-      "total_events": "1756"
+      "total_events": "1706"
     },
     {
-      "date": "2024-01-04",
-      "page_title": "Form MCS-150 and Instructions - Motor Carrier Identification Report | FMCSA",
+      "page_title": "Growth Charts - Clinical Growth Charts",
       "event_label": "file_download",
-      "file_name": "/sites/fmcsa.dot.gov/files/2023-06/mcs-150%20form.pdf",
-      "page": "www.fmcsa.dot.gov/registration/form-mcs-150-and-instructions-motor-carrier-identification-report",
-      "total_events": "1736"
+      "file_name": "/growthcharts/data/set1clinical/cj41c021.pdf",
+      "page": "www.cdc.gov/growthcharts/cdc-charts.htm",
+      "total_events": "1669"
     },
     {
-      "date": "2024-01-04",
-      "page_title": "Disability Benefits | SSA",
+      "page_title": "Diversity Visa Instructions",
       "event_label": "file_download",
-      "file_name": "/hlp/radr/10/ovw001-checklist.pdf",
-      "page": "www.ssa.gov/benefits/disability/",
-      "total_events": "1717"
+      "file_name": "/content/dam/visas/diversity-visa/dv-instructions-translations/dv-2026-instructions-translations/dv_2026_instructions_ukr.pdf",
+      "page": "travel.state.gov/content/travel/en/us-visas/immigrate/diversity-visa-program-entry/diversity-visa-instructions.html",
+      "total_events": "1640"
     },
     {
-      "date": "2024-01-04",
-      "page_title": "About Form 8822, Change of Address | Internal Revenue Service",
+      "page_title": "Change name with Social Security | SSA",
       "event_label": "file_download",
-      "file_name": "/pub/irs-pdf/f8822.pdf",
-      "page": "www.irs.gov/forms-pubs/about-form-8822",
-      "total_events": "1691"
+      "file_name": "/forms/ss-5.pdf",
+      "page": "www.ssa.gov/personal-record/change-name",
+      "total_events": "1595"
     },
     {
-      "date": "2024-01-04",
-      "page_title": "Winter Weather Experimental Probabilistic Snow and Ice",
+      "page_title": "About Form W-8 IMY, Certificate of Foreign Intermediary, Foreign Flow-Through Entity, or Certain U.S. Branches for United States Tax Withholding and Reporting | Internal Revenue Service",
       "event_label": "file_download",
-      "file_name": "/images/phi/winter/stormtotalsnowweb.jpg",
-      "page": "www.weather.gov/phi/winter",
-      "total_events": "1683"
+      "file_name": "/pub/irs-pdf/fw8imy.pdf",
+      "page": "www.irs.gov/forms-pubs/about-form-w-8-imy",
+      "total_events": "1500"
     },
     {
-      "date": "2024-01-04",
-      "page_title": "CMS 40B | CMS",
+      "page_title": "Joint Typhoon Warning Center (JTWC)",
       "event_label": "file_download",
-      "file_name": "/medicare/cms-forms/cms-forms/downloads/cms40b-e.pdf",
-      "page": "www.cms.gov/Medicare/CMS-Forms/CMS-Forms/CMS-Forms-Items/CMS017339",
-      "total_events": "1658"
+      "file_name": "/jtwc/products/wp2224web.txt",
+      "page": "www.metoc.navy.mil/jtwc/jtwc.html",
+      "total_events": "1492"
     },
     {
-      "date": "2024-01-04",
-      "page_title": "About Schedule C (Form 1040), Profit or Loss from Business (Sole Proprietorship) | Internal Revenue Service",
+      "page_title": "Army Publishing Directorate",
       "event_label": "file_download",
-      "file_name": "/pub/irs-pdf/f1040sc.pdf",
-      "page": "www.irs.gov/forms-pubs/about-schedule-c-form-1040",
-      "total_events": "1655"
+      "file_name": "/pub/eforms/dr_a/arn34523-da_form_5960-000-efile-1.pdf",
+      "page": "armypubs.army.mil/productmaps/pubform/details.aspx",
+      "total_events": "1449"
     },
     {
-      "date": "2024-01-04",
-      "page_title": "Application for Travel Document | USCIS",
+      "page_title": "Welcome to the Health Insurance Marketplace® | HealthCare.gov",
+      "event_label": "file_download",
+      "file_name": "/downloads/apply-for-or-renew-coverage.pdf",
+      "page": "www.healthcare.gov/",
+      "total_events": "1412"
+    },
+    {
+      "page_title": "About Form W-9, Request for Taxpayer Identification Number and Certification | Internal Revenue Service",
+      "event_label": "file_download",
+      "file_name": "/pub/irs-pdf/fw9.pdf",
+      "page": "www.irs.gov/forms-pubs/about-form-w-9",
+      "total_events": "1389"
+    },
+    {
+      "page_title": "Application for Naturalization | USCIS",
+      "event_label": "file_download",
+      "file_name": "/sites/default/files/document/forms/n-400.pdf",
+      "page": "www.uscis.gov/n-400",
+      "total_events": "1381"
+    },
+    {
+      "page_title": "ALEXIS FLORES — FBI",
+      "event_label": "file_download",
+      "file_name": "/wanted/topten/alexis-flores/@@download.pdf",
+      "page": "www.fbi.gov/wanted/topten/alexis-flores",
+      "total_events": "1259"
+    },
+    {
+      "page_title": "Application for Travel Documents, Parole Documents, and Arrival/Departure Records | USCIS",
       "event_label": "file_download",
       "file_name": "/sites/default/files/document/forms/i-131.pdf",
       "page": "www.uscis.gov/i-131",
-      "total_events": "1655"
+      "total_events": "1222"
     },
     {
-      "date": "2024-01-04",
-      "page_title": "Site Index Search | Internal Revenue Service",
+      "page_title": "Small Entity Compliance Guide | FinCEN.gov",
       "event_label": "file_download",
-      "file_name": "/pub/irs-pdf/f941.pdf",
-      "page": "www.irs.gov/site-index-search?query=941",
-      "total_events": "1652"
+      "file_name": "/sites/default/files/shared/boi_small_compliance_guide.v1.1-final.pdf",
+      "page": "www.fincen.gov/boi/small-entity-compliance-guide",
+      "total_events": "1217"
     },
     {
-      "date": "2024-01-04",
-      "page_title": "Apply for a Child's U.S. Passport",
+      "page_title": "About Form 1040, U.S. Individual Income Tax Return | Internal Revenue Service",
       "event_label": "file_download",
-      "file_name": "/forms/ds3053.pdf",
-      "page": "travel.state.gov/content/travel/en/passports/need-passport/under-16.html",
-      "total_events": "1649"
+      "file_name": "/pub/irs-pdf/f1040.pdf",
+      "page": "www.irs.gov/forms-pubs/about-form-1040",
+      "total_events": "1214"
     },
     {
-      "date": "2024-01-04",
-      "page_title": "Passport Forms",
+      "page_title": "Diversity Visa Instructions",
       "event_label": "file_download",
-      "file_name": "/forms/ds11.pdf",
-      "page": "travel.state.gov/content/travel/en/passports/how-apply/forms.html",
-      "total_events": "1624"
+      "file_name": "/content/dam/visas/diversity-visa/dv-instructions-translations/dv-2026-instructions-translations/dv-2026 instructions_turkish.pdf",
+      "page": "travel.state.gov/content/travel/en/us-visas/immigrate/diversity-visa-program-entry/diversity-visa-instructions.html",
+      "total_events": "1209"
     },
     {
-      "date": "2024-01-04",
-      "page_title": "Notice of Entry of Appearance as Attorney or Accredited Representative | USCIS",
+      "page_title": "Latest Satellite Imagery",
       "event_label": "file_download",
-      "file_name": "/sites/default/files/document/forms/g-28.pdf",
-      "page": "www.uscis.gov/g-28",
-      "total_events": "1596"
+      "file_name": "/goes16/abi/sector/taw/13/1800x1080.jpg",
+      "page": "www.nhc.noaa.gov/satellite.php",
+      "total_events": "1203"
     },
     {
-      "date": "2024-01-04",
-      "page_title": "About Publication 15-T, Federal Income Tax Withholding Methods | Internal Revenue Service",
+      "page_title": "Latest Satellite Imagery",
       "event_label": "file_download",
-      "file_name": "/pub/irs-pdf/p15t.pdf",
-      "page": "www.irs.gov/forms-pubs/about-publication-15-t",
-      "total_events": "1588"
+      "file_name": "/goes16/abi/sector/car/13/1000x1000.jpg",
+      "page": "www.nhc.noaa.gov/satellite.php",
+      "total_events": "1108"
     },
     {
-      "date": "2024-01-04",
-      "page_title": "Report of Immigration Medical Examination and Vaccination Record | USCIS",
+      "page_title": "Joint Typhoon Warning Center (JTWC)",
       "event_label": "file_download",
-      "file_name": "/sites/default/files/document/forms/i-693.pdf",
-      "page": "www.uscis.gov/i-693",
-      "total_events": "1571"
+      "file_name": "/jtwc/products/abpwweb.txt",
+      "page": "www.metoc.navy.mil/jtwc/jtwc.html",
+      "total_events": "1098"
     },
     {
-      "date": "2024-01-04",
-      "page_title": "About Form 5695, Residential Energy Credits | Internal Revenue Service",
-      "event_label": "file_download",
-      "file_name": "/pub/irs-pdf/f5695.pdf",
-      "page": "www.irs.gov/forms-pubs/about-form-5695",
-      "total_events": "1565"
-    },
-    {
-      "date": "2024-01-04",
-      "page_title": "About VA Form 21-526EZ | Veterans Affairs",
-      "event_label": "file_download",
-      "file_name": "/pubs/forms/vba-21-526ez-are.pdf",
-      "page": "www.va.gov/find-forms/about-form-21-526ez/",
-      "total_events": "1557"
-    },
-    {
-      "date": "2024-01-04",
-      "page_title": "Boston/Norton, MA Weather Forecast Office Winter Weather Forecasts",
-      "event_label": "file_download",
-      "file_name": "/images/box/winter/stormtotalsnow.jpg",
-      "page": "www.weather.gov/box/winter",
-      "total_events": "1551"
-    },
-    {
-      "date": "2024-01-04",
       "page_title": "Application to Register Permanent Residence or Adjust Status | USCIS",
       "event_label": "file_download",
       "file_name": "/sites/default/files/document/forms/i-485instr.pdf",
       "page": "www.uscis.gov/i-485",
-      "total_events": "1549"
+      "total_events": "1084"
     },
     {
-      "date": "2024-01-04",
-      "page_title": "Forms & Instructions | Internal Revenue Service",
+      "page_title": "BHADRESHKUMAR CHETANBHAI PATEL — FBI",
       "event_label": "file_download",
-      "file_name": "/pub/irs-pdf/fw9.pdf",
-      "page": "www.irs.gov/forms-instructions",
-      "total_events": "1549"
+      "file_name": "/wanted/topten/bhadreshkumar-chetanbhai-patel/@@download.pdf",
+      "page": "www.fbi.gov/wanted/topten/bhadreshkumar-chetanbhai-patel",
+      "total_events": "1034"
     },
     {
-      "date": "2024-01-04",
-      "page_title": "About Form 2553, Election by a Small Business Corporation | Internal Revenue Service",
+      "page_title": "Replacement card | SSA",
       "event_label": "file_download",
-      "file_name": "/pub/irs-pdf/f2553.pdf",
-      "page": "www.irs.gov/forms-pubs/about-form-2553",
-      "total_events": "1515"
+      "file_name": "/forms/ss-5.pdf",
+      "page": "www.ssa.gov/number-card/replace-card/get-started/applicant",
+      "total_events": "1024"
     },
     {
-      "date": "2024-01-04",
-      "page_title": "Forms & Instructions | Internal Revenue Service",
+      "page_title": "Joint Typhoon Warning Center (JTWC)",
       "event_label": "file_download",
-      "file_name": "/pub/irs-pdf/fw4.pdf",
-      "page": "www.irs.gov/forms-instructions",
-      "total_events": "1462"
+      "file_name": "/jtwc/products/wp9624web.txt",
+      "page": "www.metoc.navy.mil/jtwc/jtwc.html",
+      "total_events": "1018"
     },
     {
-      "date": "2024-01-04",
-      "page_title": "General Schedule",
+      "page_title": "Application to Replace Permanent Resident Card (Green Card) | USCIS",
       "event_label": "file_download",
-      "file_name": "/policy-data-oversight/pay-leave/salaries-wages/salary-tables/23tables/pdf/dcb.pdf",
-      "page": "www.opm.gov/policy-data-oversight/pay-leave/salaries-wages/2023/general-schedule/",
-      "total_events": "1456"
+      "file_name": "/sites/default/files/document/forms/i-90.pdf",
+      "page": "www.uscis.gov/i-90",
+      "total_events": "1005"
     },
     {
-      "date": "2024-01-04",
-      "page_title": "General Schedule",
+      "page_title": "RUJA IGNATOVA — FBI",
       "event_label": "file_download",
-      "file_name": "/policy-data-oversight/pay-leave/salaries-wages/salary-tables/24tables/pdf/ny.pdf",
-      "page": "www.opm.gov/policy-data-oversight/pay-leave/salaries-wages/2024/general-schedule",
-      "total_events": "1456"
+      "file_name": "/wanted/topten/ruja-ignatova/@@download.pdf",
+      "page": "www.fbi.gov/wanted/topten/ruja-ignatova",
+      "total_events": "1000"
     },
     {
-      "date": "2024-01-04",
-      "page_title": "About VA Form 21-4138 | Veterans Affairs",
-      "event_label": "file_download",
-      "file_name": "/pubs/forms/vba-21-4138-are.pdf",
-      "page": "www.va.gov/find-forms/about-form-21-4138/",
-      "total_events": "1445"
-    },
-    {
-      "date": "2024-01-04",
-      "page_title": "Inactivated Influenza Vaccine Information Statement | CDC",
-      "event_label": "file_download",
-      "file_name": "https://www.cdc.gov/vaccines/hcp/vis/vis-statements/flu.pdf",
-      "page": "www.cdc.gov/vaccines/hcp/vis/vis-statements/flu.html",
-      "total_events": "1445"
-    },
-    {
-      "date": "2024-01-04",
       "page_title": "Application for Asylum and for Withholding of Removal | USCIS",
       "event_label": "file_download",
       "file_name": "/sites/default/files/document/forms/i-589.pdf",
       "page": "www.uscis.gov/i-589",
-      "total_events": "1439"
+      "total_events": "997"
     },
     {
-      "date": "2024-01-04",
-      "page_title": "Declaration of Financial Support | USCIS",
-      "event_label": "file_download",
-      "file_name": "/sites/default/files/document/forms/i-134.pdf",
-      "page": "www.uscis.gov/i-134",
-      "total_events": "1425"
-    },
-    {
-      "date": "2024-01-04",
-      "page_title": "General Schedule",
-      "event_label": "file_download",
-      "file_name": "/policy-data-oversight/pay-leave/salaries-wages/salary-tables/24tables/pdf/atl.pdf",
-      "page": "www.opm.gov/policy-data-oversight/pay-leave/salaries-wages/2024/general-schedule",
-      "total_events": "1425"
-    },
-    {
-      "date": "2024-01-04",
-      "page_title": "Probabilistic Winter Weather Forecasts",
-      "event_label": "file_download",
-      "file_name": "/images/okx/winter/stormtotalsnowweb.jpg",
-      "page": "www.weather.gov/okx/winter",
-      "total_events": "1417"
-    },
-    {
-      "date": "2024-01-04",
-      "page_title": "Forms & Instructions | Internal Revenue Service",
-      "event_label": "file_download",
-      "file_name": "/pub/irs-pdf/f1040s.pdf",
-      "page": "www.irs.gov/forms-instructions",
-      "total_events": "1403"
-    },
-    {
-      "date": "2024-01-04",
       "page_title": "E-Notification of Application/Petition Acceptance | USCIS",
       "event_label": "file_download",
       "file_name": "/sites/default/files/document/forms/g-1145.pdf",
       "page": "www.uscis.gov/g-1145",
-      "total_events": "1395"
+      "total_events": "987"
     },
     {
-      "date": "2024-01-04",
-      "page_title": "About Form SS-4, Application for Employer Identification Number (EIN) | Internal Revenue Service",
+      "page_title": "About Form W-4, Employee's Withholding Certificate | Internal Revenue Service",
       "event_label": "file_download",
-      "file_name": "/pub/irs-pdf/fss4.pdf",
-      "page": "www.irs.gov/forms-pubs/about-form-ss-4",
-      "total_events": "1392"
+      "file_name": "/pub/irs-pdf/fw4.pdf",
+      "page": "www.irs.gov/forms-pubs/about-form-w-4",
+      "total_events": "979"
     },
     {
-      "date": "2024-01-04",
-      "page_title": "Federal Pell Grants | Federal Student Aid",
-      "event_label": "file_download",
-      "file_name": "/sites/default/files/2023-01/2023-24paymentschedule.pdf",
-      "page": "studentaid.gov/understand-aid/types/grants/pell",
-      "total_events": "1386"
-    },
-    {
-      "date": "2024-01-04",
-      "page_title": "Renew an adult passport | USAGov",
-      "event_label": "file_download",
-      "file_name": "/forms/ds82.pdf",
-      "page": "www.usa.gov/renew-adult-passport",
-      "total_events": "1369"
-    },
-    {
-      "date": "2024-01-04",
-      "page_title": "About Form W-7, Application for IRS Individual Taxpayer Identification Number | Internal Revenue Service",
-      "event_label": "file_download",
-      "file_name": "/pub/irs-pdf/fw7.pdf",
-      "page": "www.irs.gov/forms-pubs/about-form-w-7",
-      "total_events": "1367"
-    },
-    {
-      "date": "2024-01-04",
-      "page_title": "Application for Employment Authorization | USCIS",
-      "event_label": "file_download",
-      "file_name": "/sites/default/files/document/forms/i-765instr.pdf",
-      "page": "www.uscis.gov/i-765",
-      "total_events": "1367"
-    },
-    {
-      "date": "2024-01-04",
-      "page_title": "CBP DTOPS - Checkout Payment Confirmation",
-      "event_label": "file_download",
-      "file_name": "/main/paymentreceipt.pdf",
-      "page": "dtops.cbp.dhs.gov/main/paymentReturn.html",
-      "total_events": "1358"
-    },
-    {
-      "date": "2024-01-04",
-      "page_title": "Site Index Search | Internal Revenue Service",
-      "event_label": "file_download",
-      "file_name": "/pub/irs-pdf/f940.pdf",
-      "page": "www.irs.gov/site-index-search?query=940",
-      "total_events": "1358"
-    },
-    {
-      "date": "2024-01-04",
-      "page_title": "About Publication 15, (Circular E), Employer's Tax Guide | Internal Revenue Service",
-      "event_label": "file_download",
-      "file_name": "/pub/irs-pdf/p15.pdf",
-      "page": "www.irs.gov/forms-pubs/about-publication-15",
-      "total_events": "1353"
-    },
-    {
-      "date": "2024-01-04",
       "page_title": "Military Compensation > Pay > Basic Pay > Active Duty Pay",
       "event_label": "file_download",
-      "file_name": "/Portals/3/Documents/ActiveDutyTables/2024%20Pay%20Table-Capped-FINAL.pdf",
-      "page": "militarypay.defense.gov/Pay/Basic-Pay/Active-Duty-Pay/",
-      "total_events": "1353"
+      "file_name": "/portals/3/documents/activedutytables/2024 pay table-capped-final.pdf",
+      "page": "militarypay.defense.gov/pay/basic-pay/active-duty-pay/",
+      "total_events": "973"
     },
     {
-      "date": "2024-01-04",
-      "page_title": "Visa Bulletin For January 2024",
+      "page_title": "“Lotería de visas”: averigüe si es elegible y cómo participar | USAGov",
       "event_label": "file_download",
-      "file_name": "/content/dam/visas/bulletins/visabulletin_january2024.pdf",
-      "page": "travel.state.gov/content/travel/en/legal/visa-law0/visa-bulletin/2024/visa-bulletin-for-january-2024.html",
-      "total_events": "1344"
+      "file_name": "/content/dam/visas/diversity-visa/dv-instructions-translations/dv-2026-instructions-translations/dv 2026 plain language instructions and faqs.pdf",
+      "page": "www.usa.gov/es/participar-loteria-visas",
+      "total_events": "960"
     },
     {
-      "date": "2024-01-04",
       "page_title": "Affidavit of Support Under Section 213A of the INA | USCIS",
       "event_label": "file_download",
       "file_name": "/sites/default/files/document/forms/i-864instr.pdf",
       "page": "www.uscis.gov/i-864",
-      "total_events": "1302"
+      "total_events": "915"
     },
     {
-      "date": "2024-01-04",
-      "page_title": "About Form 8936, Qualified Plug-In Electric Drive Motor Vehicle Credit | Internal Revenue Service",
+      "page_title": "BOI E-FILING",
       "event_label": "file_download",
-      "file_name": "/pub/irs-pdf/f8936.pdf",
-      "page": "www.irs.gov/forms-pubs/about-form-8936",
-      "total_events": "1291"
+      "file_name": "/c8576e94532490750200.pdf",
+      "page": "boiefiling.fincen.gov/fileboir",
+      "total_events": "915"
     },
     {
-      "date": "2024-01-04",
-      "page_title": "About Form 8832, Entity Classification Election | Internal Revenue Service",
+      "page_title": "Cost-of-Living Adjustment (COLA) Information | SSA",
       "event_label": "file_download",
-      "file_name": "/pub/irs-pdf/f8832.pdf",
-      "page": "www.irs.gov/forms-pubs/about-form-8832",
-      "total_events": "1285"
+      "file_name": "/news/press/factsheets/colafacts2025.pdf",
+      "page": "www.ssa.gov/cola/",
+      "total_events": "905"
     },
     {
-      "date": "2024-01-04",
+      "page_title": "Latest Satellite Imagery",
+      "event_label": "file_download",
+      "file_name": "/goes16/abi/sector/car/geocolor/1000x1000.jpg",
+      "page": "www.nhc.noaa.gov/satellite.php",
+      "total_events": "899"
+    },
+    {
+      "page_title": "APOD: 2024 October 20 – Dark Matter in a Simulated Universe",
+      "event_label": "file_download",
+      "file_name": "/apod/image/2410/darkmatter_kipacamnh_1200.jpg",
+      "page": "apod.nasa.gov/apod/ap241020.html",
+      "total_events": "894"
+    },
+    {
+      "page_title": "Petition to Remove Conditions on Residence | USCIS",
+      "event_label": "file_download",
+      "file_name": "/sites/default/files/document/forms/i-751.pdf",
+      "page": "www.uscis.gov/i-751",
+      "total_events": "891"
+    },
+    {
       "page_title": "General Schedule",
       "event_label": "file_download",
-      "file_name": "/policy-data-oversight/pay-leave/salaries-wages/salary-tables/23tables/pdf/rus.pdf",
-      "page": "www.opm.gov/policy-data-oversight/pay-leave/salaries-wages/2023/general-schedule/",
-      "total_events": "1277"
+      "file_name": "/policy-data-oversight/pay-leave/salaries-wages/salary-tables/24tables/pdf/rus.pdf",
+      "page": "www.opm.gov/policy-data-oversight/pay-leave/salaries-wages/2024/general-schedule/",
+      "total_events": "883"
     },
     {
-      "date": "2024-01-04",
-      "page_title": "Snow and Ice Forecasts & Services",
+      "page_title": "General Schedule",
       "event_label": "file_download",
-      "file_name": "/images/lwx/winter/stormtotalsnow.jpg",
-      "page": "www.weather.gov/lwx/winter",
-      "total_events": "1266"
+      "file_name": "/policy-data-oversight/pay-leave/salaries-wages/salary-tables/24tables/pdf/dcb.pdf",
+      "page": "www.opm.gov/policy-data-oversight/pay-leave/salaries-wages/2024/general-schedule/",
+      "total_events": "873"
     },
     {
-      "date": "2024-01-04",
-      "page_title": "About VA Form 21-2680 | Veterans Affairs",
+      "page_title": "ALEJANDRO ROSALES CASTILLO — FBI",
       "event_label": "file_download",
-      "file_name": "/pubs/forms/vba-21-2680-are.pdf",
-      "page": "www.va.gov/find-forms/about-form-21-2680/",
-      "total_events": "1255"
+      "file_name": "/wanted/topten/alejandro-castillo/@@download.pdf",
+      "page": "www.fbi.gov/wanted/topten/alejandro-castillo",
+      "total_events": "862"
+    },
+    {
+      "page_title": "Joint Typhoon Warning Center (JTWC)",
+      "event_label": "file_download",
+      "file_name": "/jtwc/products/wp2224prog.txt",
+      "page": "www.metoc.navy.mil/jtwc/jtwc.html",
+      "total_events": "860"
+    },
+    {
+      "page_title": "Premiums",
+      "event_label": "file_download",
+      "file_name": "/healthcare-insurance/healthcare/plan-information/premiums/2025/fehb/2025-fehb-ffs-premium-rates.xlsx",
+      "page": "www.opm.gov/healthcare-insurance/healthcare/plan-information/premiums/",
+      "total_events": "854"
+    },
+    {
+      "page_title": "VITEL'HOMME INNOCENT — FBI",
+      "event_label": "file_download",
+      "file_name": "/wanted/topten/vitelhomme-innocent/@@download.pdf",
+      "page": "www.fbi.gov/wanted/topten/vitelhomme-innocent",
+      "total_events": "825"
+    },
+    {
+      "page_title": "Petition for Alien Fiancé(e) | USCIS",
+      "event_label": "file_download",
+      "file_name": "/sites/default/files/document/forms/i-129f.pdf",
+      "page": "www.uscis.gov/i-129f",
+      "total_events": "778"
+    },
+    {
+      "page_title": "Declaration of Financial Support | USCIS",
+      "event_label": "file_download",
+      "file_name": "/sites/default/files/document/forms/i-134.pdf",
+      "page": "www.uscis.gov/i-134",
+      "total_events": "767"
+    },
+    {
+      "page_title": "About Form W-2, Wage and Tax Statement | Internal Revenue Service",
+      "event_label": "file_download",
+      "file_name": "/pub/irs-pdf/fw2.pdf",
+      "page": "www.irs.gov/forms-pubs/about-form-w-2",
+      "total_events": "754"
+    },
+    {
+      "page_title": "Premiums",
+      "event_label": "file_download",
+      "file_name": "/healthcare-insurance/healthcare/plan-information/premiums/2025/fehb/2025-fehb-hmo-premium-rates.xlsx",
+      "page": "www.opm.gov/healthcare-insurance/healthcare/plan-information/premiums/",
+      "total_events": "751"
+    },
+    {
+      "page_title": "About Form 941, Employer's Quarterly Federal Tax Return | Internal Revenue Service",
+      "event_label": "file_download",
+      "file_name": "/pub/irs-pdf/f941.pdf",
+      "page": "www.irs.gov/forms-pubs/about-form-941",
+      "total_events": "748"
+    },
+    {
+      "page_title": "Alien’s Change of Address Card | USCIS",
+      "event_label": "file_download",
+      "file_name": "/sites/default/files/document/forms/ar-11.pdf",
+      "page": "www.uscis.gov/ar-11",
+      "total_events": "738"
+    },
+    {
+      "page_title": "Green Card | USCIS",
+      "event_label": "file_download",
+      "file_name": "/sites/default/files/document/guides/greencard_comparison_en.pdf.pdf",
+      "page": "www.uscis.gov/green-card",
+      "total_events": "738"
+    },
+    {
+      "page_title": "About Form 1040-ES, Estimated Tax for Individuals | Internal Revenue Service",
+      "event_label": "file_download",
+      "file_name": "/pub/irs-pdf/f1040es.pdf",
+      "page": "www.irs.gov/forms-pubs/about-form-1040-es",
+      "total_events": "714"
+    },
+    {
+      "page_title": "Report of Immigration Medical Examination and Vaccination Record | USCIS",
+      "event_label": "file_download",
+      "file_name": "/sites/default/files/document/forms/i-693.pdf",
+      "page": "www.uscis.gov/i-693",
+      "total_events": "701"
+    },
+    {
+      "page_title": "CBP Form 6059B Customs Declaration - English (Fillable) | U.S. Customs and Border Protection",
+      "event_label": "file_download",
+      "file_name": "/sites/default/files/2024-07/cbp_form_6059b_english_0.pdf",
+      "page": "www.cbp.gov/document/forms/form-6059b-customs-declaration-english-fillable",
+      "total_events": "698"
+    },
+    {
+      "page_title": "Medicare & You | Medicare",
+      "event_label": "file_download",
+      "file_name": "/publications/10050-medicare-and-you.pdf",
+      "page": "www.medicare.gov/medicare-and-you",
+      "total_events": "696"
+    },
+    {
+      "page_title": "Authorization for Credit Card Transactions | USCIS",
+      "event_label": "file_download",
+      "file_name": "/sites/default/files/document/forms/g-1450.pdf",
+      "page": "www.uscis.gov/g-1450",
+      "total_events": "688"
+    },
+    {
+      "page_title": "DONALD EUGENE FIELDS II — FBI",
+      "event_label": "file_download",
+      "file_name": "/wanted/topten/donald-eugene-fields-ii/@@download.pdf",
+      "page": "www.fbi.gov/wanted/topten/donald-eugene-fields-ii",
+      "total_events": "688"
+    },
+    {
+      "page_title": "Joint Typhoon Warning Center (JTWC)",
+      "event_label": "file_download",
+      "file_name": "/jtwc/products/96w_191500sair.jpg",
+      "page": "www.metoc.navy.mil/jtwc/jtwc.html",
+      "total_events": "688"
+    },
+    {
+      "page_title": "Employment Eligibility Verification | USCIS",
+      "event_label": "file_download",
+      "file_name": "/sites/default/files/document/forms/i-9instr.pdf",
+      "page": "www.uscis.gov/i-9",
+      "total_events": "685"
+    },
+    {
+      "page_title": "Latest Satellite Imagery",
+      "event_label": "file_download",
+      "file_name": "/goes16/abi/sector/taw/geocolor/1800x1080.jpg",
+      "page": "www.nhc.noaa.gov/satellite.php",
+      "total_events": "685"
+    },
+    {
+      "page_title": "Premiums",
+      "event_label": "file_download",
+      "file_name": "/healthcare-insurance/healthcare/plan-information/premiums/2025/pshb/2025-pshb-ffs-premium-rates.xlsx",
+      "page": "www.opm.gov/healthcare-insurance/healthcare/plan-information/premiums/",
+      "total_events": "682"
+    },
+    {
+      "page_title": "About Form W-4V, Voluntary Withholding Request | Internal Revenue Service",
+      "event_label": "file_download",
+      "file_name": "/pub/irs-pdf/fw4v.pdf",
+      "page": "www.irs.gov/forms-pubs/about-form-w-4-v",
+      "total_events": "677"
+    },
+    {
+      "page_title": "Apply for a Child's U.S. Passport",
+      "event_label": "file_download",
+      "file_name": "/forms/ds3053.pdf",
+      "page": "travel.state.gov/content/travel/en/passports/need-passport/under-16.html",
+      "total_events": "669"
+    },
+    {
+      "page_title": "APOD: 2024 October 19 - Comet Tsuchinshan ATLAS Flys Away",
+      "event_label": "file_download",
+      "file_name": "/apod/image/2410/c2023a3-in-the-past-6-days.jpg",
+      "page": "apod.nasa.gov/apod/ap241019.html",
+      "total_events": "666"
+    },
+    {
+      "page_title": "Forms & instructions | Internal Revenue Service",
+      "event_label": "file_download",
+      "file_name": "/pub/irs-pdf/f1040.pdf",
+      "page": "www.irs.gov/forms-instructions",
+      "total_events": "666"
+    },
+    {
+      "page_title": "Application for Naturalization | USCIS",
+      "event_label": "file_download",
+      "file_name": "/sites/default/files/document/forms/n-400instr.pdf",
+      "page": "www.uscis.gov/n-400",
+      "total_events": "664"
+    },
+    {
+      "page_title": "Growth Charts - Clinical Growth Charts",
+      "event_label": "file_download",
+      "file_name": "/growthcharts/data/set1clinical/cj41c022.pdf",
+      "page": "www.cdc.gov/growthcharts/cdc-charts.htm",
+      "total_events": "645"
+    },
+    {
+      "page_title": "Premiums",
+      "event_label": "file_download",
+      "file_name": "/healthcare-insurance/healthcare/plan-information/premiums/2025/pshb/2025-pshb-hmo-premium-rates.xlsx",
+      "page": "www.opm.gov/healthcare-insurance/healthcare/plan-information/premiums/",
+      "total_events": "624"
+    },
+    {
+      "page_title": "Latest Satellite Imagery",
+      "event_label": "file_download",
+      "file_name": "/goes16/abi/sector/gm/geocolor/1000x1000.jpg",
+      "page": "www.nhc.noaa.gov/satellite.php",
+      "total_events": "614"
+    },
+    {
+      "page_title": "Immigrant Petition for Alien Workers | USCIS",
+      "event_label": "file_download",
+      "file_name": "/sites/default/files/document/forms/i-140.pdf",
+      "page": "www.uscis.gov/i-140",
+      "total_events": "611"
+    },
+    {
+      "page_title": "Applicable Federal Rates | Internal Revenue Service",
+      "event_label": "file_download",
+      "file_name": "/pub/irs-drop/rr-24-24.pdf",
+      "page": "www.irs.gov/applicable-federal-rates",
+      "total_events": "608"
+    },
+    {
+      "page_title": "Application for Employment Authorization | USCIS",
+      "event_label": "file_download",
+      "file_name": "/sites/default/files/document/forms/i-765instr.pdf",
+      "page": "www.uscis.gov/i-765",
+      "total_events": "598"
+    },
+    {
+      "page_title": "About Form 8822, Change of Address | Internal Revenue Service",
+      "event_label": "file_download",
+      "file_name": "/pub/irs-pdf/f8822.pdf",
+      "page": "www.irs.gov/forms-pubs/about-form-8822",
+      "total_events": "587"
+    },
+    {
+      "page_title": "Reserve Drill Pay",
+      "event_label": "file_download",
+      "file_name": "/portals/3/documents/activedutytables/2024 pay table w drill pay - 1 drill period.pdf",
+      "page": "militarypay.defense.gov/pay/basic-pay/reserve-drill-pay/",
+      "total_events": "584"
+    },
+    {
+      "page_title": "A Week With the DASH Eating Plan | NHLBI, NIH",
+      "event_label": "file_download",
+      "file_name": "/sites/default/files/publications/weekondash.pdf",
+      "page": "www.nhlbi.nih.gov/resources/week-dash-eating-plan",
+      "total_events": "579"
+    },
+    {
+      "page_title": "Petition to Remove Conditions on Residence | USCIS",
+      "event_label": "file_download",
+      "file_name": "/sites/default/files/document/forms/i-751instr.pdf",
+      "page": "www.uscis.gov/i-751",
+      "total_events": "555"
+    },
+    {
+      "page_title": "General Schedule",
+      "event_label": "file_download",
+      "file_name": "/policy-data-oversight/pay-leave/salaries-wages/salary-tables/24tables/pdf/gs.pdf",
+      "page": "www.opm.gov/policy-data-oversight/pay-leave/salaries-wages/2024/general-schedule/",
+      "total_events": "553"
+    },
+    {
+      "page_title": "Rebecca's Business Plan Template - Traditional | U.S. Small Business Administration",
+      "event_label": "file_download",
+      "file_name": "/sites/default/files/2023-08/sample business plan - we can do it consulting (4).doc",
+      "page": "www.sba.gov/document/support-rebeccas-business-plan-template-traditional",
+      "total_events": "550"
+    },
+    {
+      "page_title": "BOI E-FILING",
+      "event_label": "file_download",
+      "file_name": "/resources/boir_filing_instructions.pdf",
+      "page": "boiefiling.fincen.gov/",
+      "total_events": "547"
+    },
+    {
+      "page_title": "Joint Typhoon Warning Center (JTWC)",
+      "event_label": "file_download",
+      "file_name": "/jtwc/products/abioweb.txt",
+      "page": "www.metoc.navy.mil/jtwc/jtwc.html",
+      "total_events": "540"
+    },
+    {
+      "page_title": "(not set)",
+      "event_label": "file_download",
+      "file_name": "/pitqj5emwdvc/41irxjcdfdpsj9qswibajo/e92c2ae04802641223f63589926d080e/philippines_imp.notice_english.pdf",
+      "page": "www.ustraveldocs.com/ph/en/nonimmigrant-visa",
+      "total_events": "534"
+    },
+    {
+      "page_title": "Contract Between Sponsor and Household Member | USCIS",
+      "event_label": "file_download",
+      "file_name": "/sites/default/files/document/forms/i-864a.pdf",
+      "page": "www.uscis.gov/i-864a",
+      "total_events": "532"
+    },
+    {
+      "page_title": "Ramstein AB Passenger Terminal",
+      "event_label": "file_download",
+      "file_name": "/portals/12/amc tvl pg/passenger terminals/european command terminals/ramstein ab passenger terminal/72 hr - ramstein afpims with pet info (1).pdf",
+      "page": "www.amc.af.mil/amc-travel-site/terminals/eucom-terminals/ramstein-ab-passenger-terminal/",
+      "total_events": "526"
+    },
+    {
+      "page_title": "Schedule of Social Security Payments | SSA",
+      "event_label": "file_download",
+      "file_name": "/pubs/en-05-10031-2024.pdf",
+      "page": "www.ssa.gov/pubs/calendar.htm",
+      "total_events": "524"
     }
   ],
-  "totals": {},
-  "taken_at": "2024-01-05T15:31:55.633Z"
+  "totals": {
+    "total_events": 165253
+  },
+  "taken_at": "2024-10-21T14:40:33.108Z"
 }

--- a/js/components/dashboard_content/TopDownloads.js
+++ b/js/components/dashboard_content/TopDownloads.js
@@ -47,17 +47,17 @@ function TopDownloads({
               .value((d) => +d.total_events)
               .label(
                 (d) =>
-                  `<span class="name">
-                    <a class="top-download-page" target="_blank" rel="noopener" href="http://${d.page}">
+                  `<span class="top-download__page-name">
+                    <a target="_blank" rel="noopener" href="http://${d.page}">
                       ${d.page_title}
                     </a>
                   </span>
-                  <span class="domain">
+                  <span class="top-download__page-domain">
                     ${formatters.formatURL(d.page)}
                   </span>
                   <span class="divider">/</span>
-                  <span class="filename">
-                    <a class="top-download-file" target="_blank" aria-label="${formatters.formatFile(d.file_name)}" rel="noopener" href="${formatters.formatProtocol(d.page)}${formatters.formatFile(d.file_name)}">
+                  <span class="top-download__file-location">
+                    <a target="_blank" rel="noopener" href="${d.linkUrl}">
                       download file
                     </a>
                   </span>`,

--- a/js/components/dashboard_content/TopDownloads.js
+++ b/js/components/dashboard_content/TopDownloads.js
@@ -45,26 +45,22 @@ function TopDownloads({
           .setRenderer(
             barChart()
               .value((d) => +d.total_events)
-              .label((d) =>
-                [
-                  '<span class="name"><a class="top-download-page" target="_blank" rel="noopener" href=http://',
-                  d.page,
-                  ">",
-                  d.page_title,
-                  "</a></span> ",
-                  '<span class="domain" >',
-                  formatters.formatURL(d.page),
-                  "</span> ",
-                  '<span class="divider">/</span> ',
-                  '<span class="filename"><a class="top-download-file" target="_blank" aria-label="',
-                  formatters.formatFile(d.file_name),
-                  '" rel="noopener" href=',
-                  formatters.formatProtocol(d.page),
-                  formatters.formatFile(d.file_name),
-                  ">",
-                  "download file",
-                  "</a></span>",
-                ].join(""),
+              .label(
+                (d) =>
+                  `<span class="name">
+                    <a class="top-download-page" target="_blank" rel="noopener" href="http://${d.page}">
+                      ${d.page_title}
+                    </a>
+                  </span>
+                  <span class="domain">
+                    ${formatters.formatURL(d.page)}
+                  </span>
+                  <span class="divider">/</span>
+                  <span class="filename">
+                    <a class="top-download-file" target="_blank" aria-label="${formatters.formatFile(d.file_name)}" rel="noopener" href="${formatters.formatProtocol(d.page)}${formatters.formatFile(d.file_name)}">
+                      download file
+                    </a>
+                  </span>`,
               )
               .scale((values) =>
                 d3.scale

--- a/js/components/dashboard_content/__tests__/TopDownloads.spec.js
+++ b/js/components/dashboard_content/__tests__/TopDownloads.spec.js
@@ -41,6 +41,9 @@ describe("TopDownloads", () => {
         { transient: { dataItemCount: 20 } },
       );
 
+      data.data[0].file_name =
+        "https://travel.state.gov/dv 2026 plain language instructions and faqs.pdf";
+
       DataLoader.loadJSON.mockImplementation(() => {
         return Promise.resolve(data);
       });

--- a/js/components/dashboard_content/__tests__/__snapshots__/TopDownloads.spec.js.snap
+++ b/js/components/dashboard_content/__tests__/__snapshots__/TopDownloads.spec.js.snap
@@ -15,13 +15,12 @@ exports[`TopDownloads when data is loaded renders a component with data loaded 1
           class="chart__bar-chart__item__label dark-grey text--overflow-ellipsis margin-right-8"
         >
           <span
-            class="name"
+            class="top-download__page-name"
           >
             
                     
             <a
-              class="top-download-page"
-              href="http://jagged-oatmeal.biz"
+              href="http://robust-childhood.com"
               rel="noopener"
               target="_blank"
             >
@@ -35,10 +34,10 @@ exports[`TopDownloads when data is loaded renders a component with data loaded 1
           
                   
           <span
-            class="domain"
+            class="top-download__page-domain"
           >
             
-                    jagged-oatmeal.biz
+                    robust-childhood.com
                   
           </span>
           
@@ -51,14 +50,12 @@ exports[`TopDownloads when data is loaded renders a component with data loaded 1
           
                   
           <span
-            class="filename"
+            class="top-download__file-location"
           >
             
                     
             <a
-              aria-label="/dv%202026%20plain%20language%20instructions%20and%20faqs.pdf"
-              class="top-download-file"
-              href="https://jagged-oatmeal.biz/dv%202026%20plain%20language%20instructions%20and%20faqs.pdf"
+              href="https://dizzy-ladybug.net"
               rel="noopener"
               target="_blank"
             >
@@ -73,11 +70,11 @@ exports[`TopDownloads when data is loaded renders a component with data loaded 1
         <div
           class="chart__bar-chart__item__value"
         >
-          8,997
+          3,048
         </div>
         <div
           class="chart__bar-chart__item__bar bg-light-blue"
-          style="width: 99%;"
+          style="width: 46%;"
         />
       </div>
       <div
@@ -87,13 +84,12 @@ exports[`TopDownloads when data is loaded renders a component with data loaded 1
           class="chart__bar-chart__item__label dark-grey text--overflow-ellipsis margin-right-8"
         >
           <span
-            class="name"
+            class="top-download__page-name"
           >
             
                     
             <a
-              class="top-download-page"
-              href="http://swift-chess.org"
+              href="http://early-locality.org"
               rel="noopener"
               target="_blank"
             >
@@ -107,10 +103,10 @@ exports[`TopDownloads when data is loaded renders a component with data loaded 1
           
                   
           <span
-            class="domain"
+            class="top-download__page-domain"
           >
             
-                    swift-chess.org
+                    early-locality.org
                   
           </span>
           
@@ -123,14 +119,12 @@ exports[`TopDownloads when data is loaded renders a component with data loaded 1
           
                   
           <span
-            class="filename"
+            class="top-download__file-location"
           >
             
                     
             <a
-              aria-label="partial_as_feminize.pkg"
-              class="top-download-file"
-              href="https://swift-chess.orgpartial_as_feminize.pkg"
+              href="https://questionable-lake.net"
               rel="noopener"
               target="_blank"
             >
@@ -145,11 +139,11 @@ exports[`TopDownloads when data is loaded renders a component with data loaded 1
         <div
           class="chart__bar-chart__item__value"
         >
-          9,071
+          6,120
         </div>
         <div
           class="chart__bar-chart__item__bar bg-light-blue"
-          style="width: 100%;"
+          style="width: 91%;"
         />
       </div>
       <div
@@ -159,13 +153,12 @@ exports[`TopDownloads when data is loaded renders a component with data loaded 1
           class="chart__bar-chart__item__label dark-grey text--overflow-ellipsis margin-right-8"
         >
           <span
-            class="name"
+            class="top-download__page-name"
           >
             
                     
             <a
-              class="top-download-page"
-              href="http://costly-journalist.net"
+              href="http://wide-intervention.name"
               rel="noopener"
               target="_blank"
             >
@@ -179,10 +172,10 @@ exports[`TopDownloads when data is loaded renders a component with data loaded 1
           
                   
           <span
-            class="domain"
+            class="top-download__page-domain"
           >
             
-                    costly-journalist.net
+                    wide-intervention.name
                   
           </span>
           
@@ -195,14 +188,12 @@ exports[`TopDownloads when data is loaded renders a component with data loaded 1
           
                   
           <span
-            class="filename"
+            class="top-download__file-location"
           >
             
                     
             <a
-              aria-label="inasmuch_drain.ogv"
-              class="top-download-file"
-              href="https://costly-journalist.netinasmuch_drain.ogv"
+              href="https://kindhearted-opening.biz"
               rel="noopener"
               target="_blank"
             >
@@ -217,11 +208,11 @@ exports[`TopDownloads when data is loaded renders a component with data loaded 1
         <div
           class="chart__bar-chart__item__value"
         >
-          8,505
+          4,440
         </div>
         <div
           class="chart__bar-chart__item__bar bg-light-blue"
-          style="width: 94%;"
+          style="width: 66%;"
         />
       </div>
       <div
@@ -231,13 +222,12 @@ exports[`TopDownloads when data is loaded renders a component with data loaded 1
           class="chart__bar-chart__item__label dark-grey text--overflow-ellipsis margin-right-8"
         >
           <span
-            class="name"
+            class="top-download__page-name"
           >
             
                     
             <a
-              class="top-download-page"
-              href="http://striped-twilight.name"
+              href="http://vain-coil.name"
               rel="noopener"
               target="_blank"
             >
@@ -251,10 +241,10 @@ exports[`TopDownloads when data is loaded renders a component with data loaded 1
           
                   
           <span
-            class="domain"
+            class="top-download__page-domain"
           >
             
-                    striped-twilight.name
+                    vain-coil.name
                   
           </span>
           
@@ -267,14 +257,12 @@ exports[`TopDownloads when data is loaded renders a component with data loaded 1
           
                   
           <span
-            class="filename"
+            class="top-download__file-location"
           >
             
                     
             <a
-              aria-label="so.mp4"
-              class="top-download-file"
-              href="https://striped-twilight.nameso.mp4"
+              href="https://crisp-barber.com"
               rel="noopener"
               target="_blank"
             >
@@ -289,11 +277,11 @@ exports[`TopDownloads when data is loaded renders a component with data loaded 1
         <div
           class="chart__bar-chart__item__value"
         >
-          7,699
+          494
         </div>
         <div
           class="chart__bar-chart__item__bar bg-light-blue"
-          style="width: 85%;"
+          style="width: 8%;"
         />
       </div>
       <div
@@ -303,13 +291,12 @@ exports[`TopDownloads when data is loaded renders a component with data loaded 1
           class="chart__bar-chart__item__label dark-grey text--overflow-ellipsis margin-right-8"
         >
           <span
-            class="name"
+            class="top-download__page-name"
           >
             
                     
             <a
-              class="top-download-page"
-              href="http://medical-conductor.net"
+              href="http://shameful-contest.org"
               rel="noopener"
               target="_blank"
             >
@@ -323,10 +310,10 @@ exports[`TopDownloads when data is loaded renders a component with data loaded 1
           
                   
           <span
-            class="domain"
+            class="top-download__page-domain"
           >
             
-                    medical-conductor.net
+                    shameful-contest.org
                   
           </span>
           
@@ -339,14 +326,12 @@ exports[`TopDownloads when data is loaded renders a component with data loaded 1
           
                   
           <span
-            class="filename"
+            class="top-download__file-location"
           >
             
                     
             <a
-              aria-label="jelly_woot.svg"
-              class="top-download-file"
-              href="https://medical-conductor.netjelly_woot.svg"
+              href="https://open-territory.name"
               rel="noopener"
               target="_blank"
             >
@@ -361,11 +346,11 @@ exports[`TopDownloads when data is loaded renders a component with data loaded 1
         <div
           class="chart__bar-chart__item__value"
         >
-          1,142
+          6,711
         </div>
         <div
           class="chart__bar-chart__item__bar bg-light-blue"
-          style="width: 13%;"
+          style="width: 100%;"
         />
       </div>
     </div>

--- a/js/components/dashboard_content/__tests__/__snapshots__/TopDownloads.spec.js.snap
+++ b/js/components/dashboard_content/__tests__/__snapshots__/TopDownloads.spec.js.snap
@@ -17,40 +17,57 @@ exports[`TopDownloads when data is loaded renders a component with data loaded 1
           <span
             class="name"
           >
+            
+                    
             <a
               class="top-download-page"
               href="http://jagged-oatmeal.biz"
               rel="noopener"
               target="_blank"
             >
-              deploy virtual synergies
+              
+                      deploy virtual synergies
+                    
             </a>
+            
+                  
           </span>
-           
+          
+                  
           <span
             class="domain"
           >
-            jagged-oatmeal.biz
+            
+                    jagged-oatmeal.biz
+                  
           </span>
-           
+          
+                  
           <span
             class="divider"
           >
             /
           </span>
-           
+          
+                  
           <span
             class="filename"
           >
+            
+                    
             <a
-              aria-label="inwardly.avif"
+              aria-label="/dv%202026%20plain%20language%20instructions%20and%20faqs.pdf"
               class="top-download-file"
-              href="https://jagged-oatmeal.bizinwardly.avif"
+              href="https://jagged-oatmeal.biz/dv%202026%20plain%20language%20instructions%20and%20faqs.pdf"
               rel="noopener"
               target="_blank"
             >
-              download file
+              
+                      download file
+                    
             </a>
+            
+                  
           </span>
         </div>
         <div
@@ -72,31 +89,44 @@ exports[`TopDownloads when data is loaded renders a component with data loaded 1
           <span
             class="name"
           >
+            
+                    
             <a
               class="top-download-page"
               href="http://swift-chess.org"
               rel="noopener"
               target="_blank"
             >
-              leverage back-end paradigms
+              
+                      leverage back-end paradigms
+                    
             </a>
+            
+                  
           </span>
-           
+          
+                  
           <span
             class="domain"
           >
-            swift-chess.org
+            
+                    swift-chess.org
+                  
           </span>
-           
+          
+                  
           <span
             class="divider"
           >
             /
           </span>
-           
+          
+                  
           <span
             class="filename"
           >
+            
+                    
             <a
               aria-label="partial_as_feminize.pkg"
               class="top-download-file"
@@ -104,8 +134,12 @@ exports[`TopDownloads when data is loaded renders a component with data loaded 1
               rel="noopener"
               target="_blank"
             >
-              download file
+              
+                      download file
+                    
             </a>
+            
+                  
           </span>
         </div>
         <div
@@ -127,31 +161,44 @@ exports[`TopDownloads when data is loaded renders a component with data loaded 1
           <span
             class="name"
           >
+            
+                    
             <a
               class="top-download-page"
               href="http://costly-journalist.net"
               rel="noopener"
               target="_blank"
             >
-              orchestrate efficient applications
+              
+                      orchestrate efficient applications
+                    
             </a>
+            
+                  
           </span>
-           
+          
+                  
           <span
             class="domain"
           >
-            costly-journalist.net
+            
+                    costly-journalist.net
+                  
           </span>
-           
+          
+                  
           <span
             class="divider"
           >
             /
           </span>
-           
+          
+                  
           <span
             class="filename"
           >
+            
+                    
             <a
               aria-label="inasmuch_drain.ogv"
               class="top-download-file"
@@ -159,8 +206,12 @@ exports[`TopDownloads when data is loaded renders a component with data loaded 1
               rel="noopener"
               target="_blank"
             >
-              download file
+              
+                      download file
+                    
             </a>
+            
+                  
           </span>
         </div>
         <div
@@ -182,31 +233,44 @@ exports[`TopDownloads when data is loaded renders a component with data loaded 1
           <span
             class="name"
           >
+            
+                    
             <a
               class="top-download-page"
               href="http://striped-twilight.name"
               rel="noopener"
               target="_blank"
             >
-              mesh frictionless networks
+              
+                      mesh frictionless networks
+                    
             </a>
+            
+                  
           </span>
-           
+          
+                  
           <span
             class="domain"
           >
-            striped-twilight.name
+            
+                    striped-twilight.name
+                  
           </span>
-           
+          
+                  
           <span
             class="divider"
           >
             /
           </span>
-           
+          
+                  
           <span
             class="filename"
           >
+            
+                    
             <a
               aria-label="so.mp4"
               class="top-download-file"
@@ -214,8 +278,12 @@ exports[`TopDownloads when data is loaded renders a component with data loaded 1
               rel="noopener"
               target="_blank"
             >
-              download file
+              
+                      download file
+                    
             </a>
+            
+                  
           </span>
         </div>
         <div
@@ -237,31 +305,44 @@ exports[`TopDownloads when data is loaded renders a component with data loaded 1
           <span
             class="name"
           >
+            
+                    
             <a
               class="top-download-page"
               href="http://medical-conductor.net"
               rel="noopener"
               target="_blank"
             >
-              engineer world-class networks
+              
+                      engineer world-class networks
+                    
             </a>
+            
+                  
           </span>
-           
+          
+                  
           <span
             class="domain"
           >
-            medical-conductor.net
+            
+                    medical-conductor.net
+                  
           </span>
-           
+          
+                  
           <span
             class="divider"
           >
             /
           </span>
-           
+          
+                  
           <span
             class="filename"
           >
+            
+                    
             <a
               aria-label="jelly_woot.svg"
               class="top-download-file"
@@ -269,8 +350,12 @@ exports[`TopDownloads when data is loaded renders a component with data loaded 1
               rel="noopener"
               target="_blank"
             >
-              download file
+              
+                      download file
+                    
             </a>
+            
+                  
           </span>
         </div>
         <div

--- a/js/components/dashboard_content/__tests__/__snapshots__/TopDownloadsAndVideoPlays.spec.js.snap
+++ b/js/components/dashboard_content/__tests__/__snapshots__/TopDownloadsAndVideoPlays.spec.js.snap
@@ -36,31 +36,44 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has >
             <span
               class="name"
             >
+              
+                    
               <a
                 class="top-download-page"
                 href="http://apt-metro.net"
                 rel="noopener"
                 target="_blank"
               >
-                transform user-centric paradigms
+                
+                      transform user-centric paradigms
+                    
               </a>
+              
+                  
             </span>
-             
+            
+                  
             <span
               class="domain"
             >
-              apt-metro.net
+              
+                    apt-metro.net
+                  
             </span>
-             
+            
+                  
             <span
               class="divider"
             >
               /
             </span>
-             
+            
+                  
             <span
               class="filename"
             >
+              
+                    
               <a
                 aria-label="pea_convict_alive.jsonld"
                 class="top-download-file"
@@ -68,8 +81,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has >
                 rel="noopener"
                 target="_blank"
               >
-                download file
+                
+                      download file
+                    
               </a>
+              
+                  
             </span>
           </div>
           <div
@@ -91,31 +108,44 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has >
             <span
               class="name"
             >
+              
+                    
               <a
                 class="top-download-page"
                 href="http://drab-integer.org"
                 rel="noopener"
                 target="_blank"
               >
-                scale holistic relationships
+                
+                      scale holistic relationships
+                    
               </a>
+              
+                  
             </span>
-             
+            
+                  
             <span
               class="domain"
             >
-              drab-integer.org
+              
+                    drab-integer.org
+                  
             </span>
-             
+            
+                  
             <span
               class="divider"
             >
               /
             </span>
-             
+            
+                  
             <span
               class="filename"
             >
+              
+                    
               <a
                 aria-label="realistic_down_threadbare.midi"
                 class="top-download-file"
@@ -123,8 +153,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has >
                 rel="noopener"
                 target="_blank"
               >
-                download file
+                
+                      download file
+                    
               </a>
+              
+                  
             </span>
           </div>
           <div
@@ -146,31 +180,44 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has >
             <span
               class="name"
             >
+              
+                    
               <a
                 class="top-download-page"
                 href="http://gruesome-command.org"
                 rel="noopener"
                 target="_blank"
               >
-                synergize global bandwidth
+                
+                      synergize global bandwidth
+                    
               </a>
+              
+                  
             </span>
-             
+            
+                  
             <span
               class="domain"
             >
-              gruesome-command.org
+              
+                    gruesome-command.org
+                  
             </span>
-             
+            
+                  
             <span
               class="divider"
             >
               /
             </span>
-             
+            
+                  
             <span
               class="filename"
             >
+              
+                    
               <a
                 aria-label="crime_outside.bz"
                 class="top-download-file"
@@ -178,8 +225,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has >
                 rel="noopener"
                 target="_blank"
               >
-                download file
+                
+                      download file
+                    
               </a>
+              
+                  
             </span>
           </div>
           <div
@@ -201,31 +252,44 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has >
             <span
               class="name"
             >
+              
+                    
               <a
                 class="top-download-page"
                 href="http://remarkable-gateway.info"
                 rel="noopener"
                 target="_blank"
               >
-                productize scalable niches
+                
+                      productize scalable niches
+                    
               </a>
+              
+                  
             </span>
-             
+            
+                  
             <span
               class="domain"
             >
-              remarkable-gateway.info
+              
+                    remarkable-gateway.info
+                  
             </span>
-             
+            
+                  
             <span
               class="divider"
             >
               /
             </span>
-             
+            
+                  
             <span
               class="filename"
             >
+              
+                    
               <a
                 aria-label="ack.msi"
                 class="top-download-file"
@@ -233,8 +297,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has >
                 rel="noopener"
                 target="_blank"
               >
-                download file
+                
+                      download file
+                    
               </a>
+              
+                  
             </span>
           </div>
           <div
@@ -256,31 +324,44 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has >
             <span
               class="name"
             >
+              
+                    
               <a
                 class="top-download-page"
                 href="http://incomparable-corporation.org"
                 rel="noopener"
                 target="_blank"
               >
-                synthesize collaborative blockchains
+                
+                      synthesize collaborative blockchains
+                    
               </a>
+              
+                  
             </span>
-             
+            
+                  
             <span
               class="domain"
             >
-              incomparable-corporation.org
+              
+                    incomparable-corporation.org
+                  
             </span>
-             
+            
+                  
             <span
               class="divider"
             >
               /
             </span>
-             
+            
+                  
             <span
               class="filename"
             >
+              
+                    
               <a
                 aria-label="atop_psst.pps"
                 class="top-download-file"
@@ -288,8 +369,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has >
                 rel="noopener"
                 target="_blank"
               >
-                download file
+                
+                      download file
+                    
               </a>
+              
+                  
             </span>
           </div>
           <div
@@ -311,31 +396,44 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has >
             <span
               class="name"
             >
+              
+                    
               <a
                 class="top-download-page"
                 href="http://dapper-espalier.info"
                 rel="noopener"
                 target="_blank"
               >
-                cultivate global functionalities
+                
+                      cultivate global functionalities
+                    
               </a>
+              
+                  
             </span>
-             
+            
+                  
             <span
               class="domain"
             >
-              dapper-espalier.info
+              
+                    dapper-espalier.info
+                  
             </span>
-             
+            
+                  
             <span
               class="divider"
             >
               /
             </span>
-             
+            
+                  
             <span
               class="filename"
             >
+              
+                    
               <a
                 aria-label="judicious_or.pptx"
                 class="top-download-file"
@@ -343,8 +441,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has >
                 rel="noopener"
                 target="_blank"
               >
-                download file
+                
+                      download file
+                    
               </a>
+              
+                  
             </span>
           </div>
           <div
@@ -366,31 +468,44 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has >
             <span
               class="name"
             >
+              
+                    
               <a
                 class="top-download-page"
                 href="http://imaginative-soy.biz"
                 rel="noopener"
                 target="_blank"
               >
-                synthesize leading-edge relationships
+                
+                      synthesize leading-edge relationships
+                    
               </a>
+              
+                  
             </span>
-             
+            
+                  
             <span
               class="domain"
             >
-              imaginative-soy.biz
+              
+                    imaginative-soy.biz
+                  
             </span>
-             
+            
+                  
             <span
               class="divider"
             >
               /
             </span>
-             
+            
+                  
             <span
               class="filename"
             >
+              
+                    
               <a
                 aria-label="failing_modulate.txt"
                 class="top-download-file"
@@ -398,8 +513,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has >
                 rel="noopener"
                 target="_blank"
               >
-                download file
+                
+                      download file
+                    
               </a>
+              
+                  
             </span>
           </div>
           <div
@@ -421,31 +540,44 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has >
             <span
               class="name"
             >
+              
+                    
               <a
                 class="top-download-page"
                 href="http://juvenile-earthquake.name"
                 rel="noopener"
                 target="_blank"
               >
-                redefine transparent eyeballs
+                
+                      redefine transparent eyeballs
+                    
               </a>
+              
+                  
             </span>
-             
+            
+                  
             <span
               class="domain"
             >
-              juvenile-earthquake.name
+              
+                    juvenile-earthquake.name
+                  
             </span>
-             
+            
+                  
             <span
               class="divider"
             >
               /
             </span>
-             
+            
+                  
             <span
               class="filename"
             >
+              
+                    
               <a
                 aria-label="awake_with_petition.xht"
                 class="top-download-file"
@@ -453,8 +585,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has >
                 rel="noopener"
                 target="_blank"
               >
-                download file
+                
+                      download file
+                    
               </a>
+              
+                  
             </span>
           </div>
           <div
@@ -476,31 +612,44 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has >
             <span
               class="name"
             >
+              
+                    
               <a
                 class="top-download-page"
                 href="http://equal-bronze.com"
                 rel="noopener"
                 target="_blank"
               >
-                engage best-of-breed initiatives
+                
+                      engage best-of-breed initiatives
+                    
               </a>
+              
+                  
             </span>
-             
+            
+                  
             <span
               class="domain"
             >
-              equal-bronze.com
+              
+                    equal-bronze.com
+                  
             </span>
-             
+            
+                  
             <span
               class="divider"
             >
               /
             </span>
-             
+            
+                  
             <span
               class="filename"
             >
+              
+                    
               <a
                 aria-label="yowza_although.ogg"
                 class="top-download-file"
@@ -508,8 +657,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has >
                 rel="noopener"
                 target="_blank"
               >
-                download file
+                
+                      download file
+                    
               </a>
+              
+                  
             </span>
           </div>
           <div
@@ -531,31 +684,44 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has >
             <span
               class="name"
             >
+              
+                    
               <a
                 class="top-download-page"
                 href="http://innocent-bail.name"
                 rel="noopener"
                 target="_blank"
               >
-                transition B2C eyeballs
+                
+                      transition B2C eyeballs
+                    
               </a>
+              
+                  
             </span>
-             
+            
+                  
             <span
               class="domain"
             >
-              innocent-bail.name
+              
+                    innocent-bail.name
+                  
             </span>
-             
+            
+                  
             <span
               class="divider"
             >
               /
             </span>
-             
+            
+                  
             <span
               class="filename"
             >
+              
+                    
               <a
                 aria-label="by_boohoo.list"
                 class="top-download-file"
@@ -563,8 +729,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has >
                 rel="noopener"
                 target="_blank"
               >
-                download file
+                
+                      download file
+                    
               </a>
+              
+                  
             </span>
           </div>
           <div
@@ -883,31 +1053,44 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has 2
             <span
               class="name"
             >
+              
+                    
               <a
                 class="top-download-page"
                 href="http://healthy-wedding.com"
                 rel="noopener"
                 target="_blank"
               >
-                matrix turn-key architectures
+                
+                      matrix turn-key architectures
+                    
               </a>
+              
+                  
             </span>
-             
+            
+                  
             <span
               class="domain"
             >
-              healthy-wedding.com
+              
+                    healthy-wedding.com
+                  
             </span>
-             
+            
+                  
             <span
               class="divider"
             >
               /
             </span>
-             
+            
+                  
             <span
               class="filename"
             >
+              
+                    
               <a
                 aria-label="grate.dist"
                 class="top-download-file"
@@ -915,8 +1098,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has 2
                 rel="noopener"
                 target="_blank"
               >
-                download file
+                
+                      download file
+                    
               </a>
+              
+                  
             </span>
           </div>
           <div
@@ -938,31 +1125,44 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has 2
             <span
               class="name"
             >
+              
+                    
               <a
                 class="top-download-page"
                 href="http://grandiose-maker.info"
                 rel="noopener"
                 target="_blank"
               >
-                enhance world-class web services
+                
+                      enhance world-class web services
+                    
               </a>
+              
+                  
             </span>
-             
+            
+                  
             <span
               class="domain"
             >
-              grandiose-maker.info
+              
+                    grandiose-maker.info
+                  
             </span>
-             
+            
+                  
             <span
               class="divider"
             >
               /
             </span>
-             
+            
+                  
             <span
               class="filename"
             >
+              
+                    
               <a
                 aria-label="tremendously_foolishly_considerate.mp2a"
                 class="top-download-file"
@@ -970,8 +1170,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has 2
                 rel="noopener"
                 target="_blank"
               >
-                download file
+                
+                      download file
+                    
               </a>
+              
+                  
             </span>
           </div>
           <div
@@ -993,31 +1197,44 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has 2
             <span
               class="name"
             >
+              
+                    
               <a
                 class="top-download-page"
                 href="http://demanding-clipboard.info"
                 rel="noopener"
                 target="_blank"
               >
-                mesh innovative mindshare
+                
+                      mesh innovative mindshare
+                    
               </a>
+              
+                  
             </span>
-             
+            
+                  
             <span
               class="domain"
             >
-              demanding-clipboard.info
+              
+                    demanding-clipboard.info
+                  
             </span>
-             
+            
+                  
             <span
               class="divider"
             >
               /
             </span>
-             
+            
+                  
             <span
               class="filename"
             >
+              
+                    
               <a
                 aria-label="discard_minus.mp2"
                 class="top-download-file"
@@ -1025,8 +1242,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has 2
                 rel="noopener"
                 target="_blank"
               >
-                download file
+                
+                      download file
+                    
               </a>
+              
+                  
             </span>
           </div>
           <div
@@ -1048,31 +1269,44 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has 2
             <span
               class="name"
             >
+              
+                    
               <a
                 class="top-download-page"
                 href="http://rotten-dad.info"
                 rel="noopener"
                 target="_blank"
               >
-                seize real-time technologies
+                
+                      seize real-time technologies
+                    
               </a>
+              
+                  
             </span>
-             
+            
+                  
             <span
               class="domain"
             >
-              rotten-dad.info
+              
+                    rotten-dad.info
+                  
             </span>
-             
+            
+                  
             <span
               class="divider"
             >
               /
             </span>
-             
+            
+                  
             <span
               class="filename"
             >
+              
+                    
               <a
                 aria-label="up_grace_doubtfully.m2v"
                 class="top-download-file"
@@ -1080,8 +1314,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has 2
                 rel="noopener"
                 target="_blank"
               >
-                download file
+                
+                      download file
+                    
               </a>
+              
+                  
             </span>
           </div>
           <div
@@ -1103,31 +1341,44 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has 2
             <span
               class="name"
             >
+              
+                    
               <a
                 class="top-download-page"
                 href="http://conscious-chord.com"
                 rel="noopener"
                 target="_blank"
               >
-                utilize revolutionary users
+                
+                      utilize revolutionary users
+                    
               </a>
+              
+                  
             </span>
-             
+            
+                  
             <span
               class="domain"
             >
-              conscious-chord.com
+              
+                    conscious-chord.com
+                  
             </span>
-             
+            
+                  
             <span
               class="divider"
             >
               /
             </span>
-             
+            
+                  
             <span
               class="filename"
             >
+              
+                    
               <a
                 aria-label="per.ini"
                 class="top-download-file"
@@ -1135,8 +1386,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has 2
                 rel="noopener"
                 target="_blank"
               >
-                download file
+                
+                      download file
+                    
               </a>
+              
+                  
             </span>
           </div>
           <div
@@ -1158,31 +1413,44 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has 2
             <span
               class="name"
             >
+              
+                    
               <a
                 class="top-download-page"
                 href="http://strong-burn-out.com"
                 rel="noopener"
                 target="_blank"
               >
-                scale magnetic metrics
+                
+                      scale magnetic metrics
+                    
               </a>
+              
+                  
             </span>
-             
+            
+                  
             <span
               class="domain"
             >
-              strong-burn-out.com
+              
+                    strong-burn-out.com
+                  
             </span>
-             
+            
+                  
             <span
               class="divider"
             >
               /
             </span>
-             
+            
+                  
             <span
               class="filename"
             >
+              
+                    
               <a
                 aria-label="hastily.dll"
                 class="top-download-file"
@@ -1190,8 +1458,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has 2
                 rel="noopener"
                 target="_blank"
               >
-                download file
+                
+                      download file
+                    
               </a>
+              
+                  
             </span>
           </div>
           <div
@@ -1213,31 +1485,44 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has 2
             <span
               class="name"
             >
+              
+                    
               <a
                 class="top-download-page"
                 href="http://wasteful-temptation.biz"
                 rel="noopener"
                 target="_blank"
               >
-                facilitate back-end solutions
+                
+                      facilitate back-end solutions
+                    
               </a>
+              
+                  
             </span>
-             
+            
+                  
             <span
               class="domain"
             >
-              wasteful-temptation.biz
+              
+                    wasteful-temptation.biz
+                  
             </span>
-             
+            
+                  
             <span
               class="divider"
             >
               /
             </span>
-             
+            
+                  
             <span
               class="filename"
             >
+              
+                    
               <a
                 aria-label="casket.webm"
                 class="top-download-file"
@@ -1245,8 +1530,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has 2
                 rel="noopener"
                 target="_blank"
               >
-                download file
+                
+                      download file
+                    
               </a>
+              
+                  
             </span>
           </div>
           <div
@@ -1268,31 +1557,44 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has 2
             <span
               class="name"
             >
+              
+                    
               <a
                 class="top-download-page"
                 href="http://sore-event.name"
                 rel="noopener"
                 target="_blank"
               >
-                streamline global ROI
+                
+                      streamline global ROI
+                    
               </a>
+              
+                  
             </span>
-             
+            
+                  
             <span
               class="domain"
             >
-              sore-event.name
+              
+                    sore-event.name
+                  
             </span>
-             
+            
+                  
             <span
               class="divider"
             >
               /
             </span>
-             
+            
+                  
             <span
               class="filename"
             >
+              
+                    
               <a
                 aria-label="author_regale_describe.js"
                 class="top-download-file"
@@ -1300,8 +1602,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has 2
                 rel="noopener"
                 target="_blank"
               >
-                download file
+                
+                      download file
+                    
               </a>
+              
+                  
             </span>
           </div>
           <div
@@ -1323,31 +1629,44 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has 2
             <span
               class="name"
             >
+              
+                    
               <a
                 class="top-download-page"
                 href="http://plush-company.info"
                 rel="noopener"
                 target="_blank"
               >
-                engage transparent initiatives
+                
+                      engage transparent initiatives
+                    
               </a>
+              
+                  
             </span>
-             
+            
+                  
             <span
               class="domain"
             >
-              plush-company.info
+              
+                    plush-company.info
+                  
             </span>
-             
+            
+                  
             <span
               class="divider"
             >
               /
             </span>
-             
+            
+                  
             <span
               class="filename"
             >
+              
+                    
               <a
                 aria-label="clearly.bpk"
                 class="top-download-file"
@@ -1355,8 +1674,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has 2
                 rel="noopener"
                 target="_blank"
               >
-                download file
+                
+                      download file
+                    
               </a>
+              
+                  
             </span>
           </div>
           <div
@@ -1378,31 +1701,44 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has 2
             <span
               class="name"
             >
+              
+                    
               <a
                 class="top-download-page"
                 href="http://outstanding-mouth.biz"
                 rel="noopener"
                 target="_blank"
               >
-                enable customized solutions
+                
+                      enable customized solutions
+                    
               </a>
+              
+                  
             </span>
-             
+            
+                  
             <span
               class="domain"
             >
-              outstanding-mouth.biz
+              
+                    outstanding-mouth.biz
+                  
             </span>
-             
+            
+                  
             <span
               class="divider"
             >
               /
             </span>
-             
+            
+                  
             <span
               class="filename"
             >
+              
+                    
               <a
                 aria-label="how_filter.mp4v"
                 class="top-download-file"
@@ -1410,8 +1746,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has 2
                 rel="noopener"
                 target="_blank"
               >
-                download file
+                
+                      download file
+                    
               </a>
+              
+                  
             </span>
           </div>
           <div
@@ -1433,31 +1773,44 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has 2
             <span
               class="name"
             >
+              
+                    
               <a
                 class="top-download-page"
                 href="http://doting-drizzle.name"
                 rel="noopener"
                 target="_blank"
               >
-                monetize extensible initiatives
+                
+                      monetize extensible initiatives
+                    
               </a>
+              
+                  
             </span>
-             
+            
+                  
             <span
               class="domain"
             >
-              doting-drizzle.name
+              
+                    doting-drizzle.name
+                  
             </span>
-             
+            
+                  
             <span
               class="divider"
             >
               /
             </span>
-             
+            
+                  
             <span
               class="filename"
             >
+              
+                    
               <a
                 aria-label="kind_nearer_although.dist"
                 class="top-download-file"
@@ -1465,8 +1818,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has 2
                 rel="noopener"
                 target="_blank"
               >
-                download file
+                
+                      download file
+                    
               </a>
+              
+                  
             </span>
           </div>
           <div
@@ -1488,31 +1845,44 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has 2
             <span
               class="name"
             >
+              
+                    
               <a
                 class="top-download-page"
                 href="http://honored-freak.name"
                 rel="noopener"
                 target="_blank"
               >
-                implement clicks-and-mortar e-commerce
+                
+                      implement clicks-and-mortar e-commerce
+                    
               </a>
+              
+                  
             </span>
-             
+            
+                  
             <span
               class="domain"
             >
-              honored-freak.name
+              
+                    honored-freak.name
+                  
             </span>
-             
+            
+                  
             <span
               class="divider"
             >
               /
             </span>
-             
+            
+                  
             <span
               class="filename"
             >
+              
+                    
               <a
                 aria-label="original_but.m2a"
                 class="top-download-file"
@@ -1520,8 +1890,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has 2
                 rel="noopener"
                 target="_blank"
               >
-                download file
+                
+                      download file
+                    
               </a>
+              
+                  
             </span>
           </div>
           <div
@@ -1543,31 +1917,44 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has 2
             <span
               class="name"
             >
+              
+                    
               <a
                 class="top-download-page"
                 href="http://true-glockenspiel.name"
                 rel="noopener"
                 target="_blank"
               >
-                synergize best-of-breed schemas
+                
+                      synergize best-of-breed schemas
+                    
               </a>
+              
+                  
             </span>
-             
+            
+                  
             <span
               class="domain"
             >
-              true-glockenspiel.name
+              
+                    true-glockenspiel.name
+                  
             </span>
-             
+            
+                  
             <span
               class="divider"
             >
               /
             </span>
-             
+            
+                  
             <span
               class="filename"
             >
+              
+                    
               <a
                 aria-label="ha_translate_after.distz"
                 class="top-download-file"
@@ -1575,8 +1962,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has 2
                 rel="noopener"
                 target="_blank"
               >
-                download file
+                
+                      download file
+                    
               </a>
+              
+                  
             </span>
           </div>
           <div
@@ -1598,31 +1989,44 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has 2
             <span
               class="name"
             >
+              
+                    
               <a
                 class="top-download-page"
                 href="http://tart-relay.org"
                 rel="noopener"
                 target="_blank"
               >
-                harness one-to-one solutions
+                
+                      harness one-to-one solutions
+                    
               </a>
+              
+                  
             </span>
-             
+            
+                  
             <span
               class="domain"
             >
-              tart-relay.org
+              
+                    tart-relay.org
+                  
             </span>
-             
+            
+                  
             <span
               class="divider"
             >
               /
             </span>
-             
+            
+                  
             <span
               class="filename"
             >
+              
+                    
               <a
                 aria-label="sanction_ew_glorious.xul"
                 class="top-download-file"
@@ -1630,8 +2034,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has 2
                 rel="noopener"
                 target="_blank"
               >
-                download file
+                
+                      download file
+                    
               </a>
+              
+                  
             </span>
           </div>
           <div
@@ -1653,31 +2061,44 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has 2
             <span
               class="name"
             >
+              
+                    
               <a
                 class="top-download-page"
                 href="http://spirited-sanctuary.biz"
                 rel="noopener"
                 target="_blank"
               >
-                morph e-business technologies
+                
+                      morph e-business technologies
+                    
               </a>
+              
+                  
             </span>
-             
+            
+                  
             <span
               class="domain"
             >
-              spirited-sanctuary.biz
+              
+                    spirited-sanctuary.biz
+                  
             </span>
-             
+            
+                  
             <span
               class="divider"
             >
               /
             </span>
-             
+            
+                  
             <span
               class="filename"
             >
+              
+                    
               <a
                 aria-label="vivid_elk_sleepy.midi"
                 class="top-download-file"
@@ -1685,8 +2106,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has 2
                 rel="noopener"
                 target="_blank"
               >
-                download file
+                
+                      download file
+                    
               </a>
+              
+                  
             </span>
           </div>
           <div
@@ -1708,31 +2133,44 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has 2
             <span
               class="name"
             >
+              
+                    
               <a
                 class="top-download-page"
                 href="http://hilarious-destiny.info"
                 rel="noopener"
                 target="_blank"
               >
-                engage web-enabled functionalities
+                
+                      engage web-enabled functionalities
+                    
               </a>
+              
+                  
             </span>
-             
+            
+                  
             <span
               class="domain"
             >
-              hilarious-destiny.info
+              
+                    hilarious-destiny.info
+                  
             </span>
-             
+            
+                  
             <span
               class="divider"
             >
               /
             </span>
-             
+            
+                  
             <span
               class="filename"
             >
+              
+                    
               <a
                 aria-label="emphasize_psst.pps"
                 class="top-download-file"
@@ -1740,8 +2178,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has 2
                 rel="noopener"
                 target="_blank"
               >
-                download file
+                
+                      download file
+                    
               </a>
+              
+                  
             </span>
           </div>
           <div
@@ -1763,31 +2205,44 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has 2
             <span
               class="name"
             >
+              
+                    
               <a
                 class="top-download-page"
                 href="http://intent-elbow.net"
                 rel="noopener"
                 target="_blank"
               >
-                seize viral solutions
+                
+                      seize viral solutions
+                    
               </a>
+              
+                  
             </span>
-             
+            
+                  
             <span
               class="domain"
             >
-              intent-elbow.net
+              
+                    intent-elbow.net
+                  
             </span>
-             
+            
+                  
             <span
               class="divider"
             >
               /
             </span>
-             
+            
+                  
             <span
               class="filename"
             >
+              
+                    
               <a
                 aria-label="regarding_retention.zip"
                 class="top-download-file"
@@ -1795,8 +2250,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has 2
                 rel="noopener"
                 target="_blank"
               >
-                download file
+                
+                      download file
+                    
               </a>
+              
+                  
             </span>
           </div>
           <div
@@ -1818,31 +2277,44 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has 2
             <span
               class="name"
             >
+              
+                    
               <a
                 class="top-download-page"
                 href="http://rude-war.name"
                 rel="noopener"
                 target="_blank"
               >
-                synergize wireless synergies
+                
+                      synergize wireless synergies
+                    
               </a>
+              
+                  
             </span>
-             
+            
+                  
             <span
               class="domain"
             >
-              rude-war.name
+              
+                    rude-war.name
+                  
             </span>
-             
+            
+                  
             <span
               class="divider"
             >
               /
             </span>
-             
+            
+                  
             <span
               class="filename"
             >
+              
+                    
               <a
                 aria-label="safely_heavenly_rumour.json"
                 class="top-download-file"
@@ -1850,8 +2322,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has 2
                 rel="noopener"
                 target="_blank"
               >
-                download file
+                
+                      download file
+                    
               </a>
+              
+                  
             </span>
           </div>
           <div
@@ -1873,31 +2349,44 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has 2
             <span
               class="name"
             >
+              
+                    
               <a
                 class="top-download-page"
                 href="http://productive-crocodile.org"
                 rel="noopener"
                 target="_blank"
               >
-                matrix frictionless bandwidth
+                
+                      matrix frictionless bandwidth
+                    
               </a>
+              
+                  
             </span>
-             
+            
+                  
             <span
               class="domain"
             >
-              productive-crocodile.org
+              
+                    productive-crocodile.org
+                  
             </span>
-             
+            
+                  
             <span
               class="divider"
             >
               /
             </span>
-             
+            
+                  
             <span
               class="filename"
             >
+              
+                    
               <a
                 aria-label="mmm_ah_aha.list"
                 class="top-download-file"
@@ -1905,8 +2394,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has 2
                 rel="noopener"
                 target="_blank"
               >
-                download file
+                
+                      download file
+                    
               </a>
+              
+                  
             </span>
           </div>
           <div
@@ -1928,31 +2421,44 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has 2
             <span
               class="name"
             >
+              
+                    
               <a
                 class="top-download-page"
                 href="http://clear-cut-disappointment.info"
                 rel="noopener"
                 target="_blank"
               >
-                brand killer web services
+                
+                      brand killer web services
+                    
               </a>
+              
+                  
             </span>
-             
+            
+                  
             <span
               class="domain"
             >
-              clear-cut-disappointment.info
+              
+                    clear-cut-disappointment.info
+                  
             </span>
-             
+            
+                  
             <span
               class="divider"
             >
               /
             </span>
-             
+            
+                  
             <span
               class="filename"
             >
+              
+                    
               <a
                 aria-label="busy_under_under.arc"
                 class="top-download-file"
@@ -1960,8 +2466,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has 2
                 rel="noopener"
                 target="_blank"
               >
-                download file
+                
+                      download file
+                    
               </a>
+              
+                  
             </span>
           </div>
           <div
@@ -2033,31 +2543,44 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
             <span
               class="name"
             >
+              
+                    
               <a
                 class="top-download-page"
                 href="http://jagged-oatmeal.biz"
                 rel="noopener"
                 target="_blank"
               >
-                deploy virtual synergies
+                
+                      deploy virtual synergies
+                    
               </a>
+              
+                  
             </span>
-             
+            
+                  
             <span
               class="domain"
             >
-              jagged-oatmeal.biz
+              
+                    jagged-oatmeal.biz
+                  
             </span>
-             
+            
+                  
             <span
               class="divider"
             >
               /
             </span>
-             
+            
+                  
             <span
               class="filename"
             >
+              
+                    
               <a
                 aria-label="inwardly.avif"
                 class="top-download-file"
@@ -2065,8 +2588,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
                 rel="noopener"
                 target="_blank"
               >
-                download file
+                
+                      download file
+                    
               </a>
+              
+                  
             </span>
           </div>
           <div
@@ -2088,31 +2615,44 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
             <span
               class="name"
             >
+              
+                    
               <a
                 class="top-download-page"
                 href="http://swift-chess.org"
                 rel="noopener"
                 target="_blank"
               >
-                leverage back-end paradigms
+                
+                      leverage back-end paradigms
+                    
               </a>
+              
+                  
             </span>
-             
+            
+                  
             <span
               class="domain"
             >
-              swift-chess.org
+              
+                    swift-chess.org
+                  
             </span>
-             
+            
+                  
             <span
               class="divider"
             >
               /
             </span>
-             
+            
+                  
             <span
               class="filename"
             >
+              
+                    
               <a
                 aria-label="partial_as_feminize.pkg"
                 class="top-download-file"
@@ -2120,8 +2660,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
                 rel="noopener"
                 target="_blank"
               >
-                download file
+                
+                      download file
+                    
               </a>
+              
+                  
             </span>
           </div>
           <div
@@ -2143,31 +2687,44 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
             <span
               class="name"
             >
+              
+                    
               <a
                 class="top-download-page"
                 href="http://costly-journalist.net"
                 rel="noopener"
                 target="_blank"
               >
-                orchestrate efficient applications
+                
+                      orchestrate efficient applications
+                    
               </a>
+              
+                  
             </span>
-             
+            
+                  
             <span
               class="domain"
             >
-              costly-journalist.net
+              
+                    costly-journalist.net
+                  
             </span>
-             
+            
+                  
             <span
               class="divider"
             >
               /
             </span>
-             
+            
+                  
             <span
               class="filename"
             >
+              
+                    
               <a
                 aria-label="inasmuch_drain.ogv"
                 class="top-download-file"
@@ -2175,8 +2732,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
                 rel="noopener"
                 target="_blank"
               >
-                download file
+                
+                      download file
+                    
               </a>
+              
+                  
             </span>
           </div>
           <div
@@ -2198,31 +2759,44 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
             <span
               class="name"
             >
+              
+                    
               <a
                 class="top-download-page"
                 href="http://striped-twilight.name"
                 rel="noopener"
                 target="_blank"
               >
-                mesh frictionless networks
+                
+                      mesh frictionless networks
+                    
               </a>
+              
+                  
             </span>
-             
+            
+                  
             <span
               class="domain"
             >
-              striped-twilight.name
+              
+                    striped-twilight.name
+                  
             </span>
-             
+            
+                  
             <span
               class="divider"
             >
               /
             </span>
-             
+            
+                  
             <span
               class="filename"
             >
+              
+                    
               <a
                 aria-label="so.mp4"
                 class="top-download-file"
@@ -2230,8 +2804,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
                 rel="noopener"
                 target="_blank"
               >
-                download file
+                
+                      download file
+                    
               </a>
+              
+                  
             </span>
           </div>
           <div
@@ -2253,31 +2831,44 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
             <span
               class="name"
             >
+              
+                    
               <a
                 class="top-download-page"
                 href="http://medical-conductor.net"
                 rel="noopener"
                 target="_blank"
               >
-                engineer world-class networks
+                
+                      engineer world-class networks
+                    
               </a>
+              
+                  
             </span>
-             
+            
+                  
             <span
               class="domain"
             >
-              medical-conductor.net
+              
+                    medical-conductor.net
+                  
             </span>
-             
+            
+                  
             <span
               class="divider"
             >
               /
             </span>
-             
+            
+                  
             <span
               class="filename"
             >
+              
+                    
               <a
                 aria-label="jelly_woot.svg"
                 class="top-download-file"
@@ -2285,8 +2876,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
                 rel="noopener"
                 target="_blank"
               >
-                download file
+                
+                      download file
+                    
               </a>
+              
+                  
             </span>
           </div>
           <div
@@ -2308,31 +2903,44 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
             <span
               class="name"
             >
+              
+                    
               <a
                 class="top-download-page"
                 href="http://fatal-subscription.name"
                 rel="noopener"
                 target="_blank"
               >
-                envisioneer cross-platform web services
+                
+                      envisioneer cross-platform web services
+                    
               </a>
+              
+                  
             </span>
-             
+            
+                  
             <span
               class="domain"
             >
-              fatal-subscription.name
+              
+                    fatal-subscription.name
+                  
             </span>
-             
+            
+                  
             <span
               class="divider"
             >
               /
             </span>
-             
+            
+                  
             <span
               class="filename"
             >
+              
+                    
               <a
                 aria-label="inquisitively.ods"
                 class="top-download-file"
@@ -2340,8 +2948,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
                 rel="noopener"
                 target="_blank"
               >
-                download file
+                
+                      download file
+                    
               </a>
+              
+                  
             </span>
           </div>
           <div
@@ -2363,31 +2975,44 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
             <span
               class="name"
             >
+              
+                    
               <a
                 class="top-download-page"
                 href="http://pleasing-ramie.biz"
                 rel="noopener"
                 target="_blank"
               >
-                syndicate vertical technologies
+                
+                      syndicate vertical technologies
+                    
               </a>
+              
+                  
             </span>
-             
+            
+                  
             <span
               class="domain"
             >
-              pleasing-ramie.biz
+              
+                    pleasing-ramie.biz
+                  
             </span>
-             
+            
+                  
             <span
               class="divider"
             >
               /
             </span>
-             
+            
+                  
             <span
               class="filename"
             >
+              
+                    
               <a
                 aria-label="applaud.img"
                 class="top-download-file"
@@ -2395,8 +3020,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
                 rel="noopener"
                 target="_blank"
               >
-                download file
+                
+                      download file
+                    
               </a>
+              
+                  
             </span>
           </div>
           <div
@@ -2418,31 +3047,44 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
             <span
               class="name"
             >
+              
+                    
               <a
                 class="top-download-page"
                 href="http://ornery-thaw.org"
                 rel="noopener"
                 target="_blank"
               >
-                enable viral interfaces
+                
+                      enable viral interfaces
+                    
               </a>
+              
+                  
             </span>
-             
+            
+                  
             <span
               class="domain"
             >
-              ornery-thaw.org
+              
+                    ornery-thaw.org
+                  
             </span>
-             
+            
+                  
             <span
               class="divider"
             >
               /
             </span>
-             
+            
+                  
             <span
               class="filename"
             >
+              
+                    
               <a
                 aria-label="blah_wherever.dms"
                 class="top-download-file"
@@ -2450,8 +3092,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
                 rel="noopener"
                 target="_blank"
               >
-                download file
+                
+                      download file
+                    
               </a>
+              
+                  
             </span>
           </div>
           <div
@@ -2473,31 +3119,44 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
             <span
               class="name"
             >
+              
+                    
               <a
                 class="top-download-page"
                 href="http://watchful-maelstrom.org"
                 rel="noopener"
                 target="_blank"
               >
-                expedite out-of-the-box blockchains
+                
+                      expedite out-of-the-box blockchains
+                    
               </a>
+              
+                  
             </span>
-             
+            
+                  
             <span
               class="domain"
             >
-              watchful-maelstrom.org
+              
+                    watchful-maelstrom.org
+                  
             </span>
-             
+            
+                  
             <span
               class="divider"
             >
               /
             </span>
-             
+            
+                  
             <span
               class="filename"
             >
+              
+                    
               <a
                 aria-label="safe_dear.distz"
                 class="top-download-file"
@@ -2505,8 +3164,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
                 rel="noopener"
                 target="_blank"
               >
-                download file
+                
+                      download file
+                    
               </a>
+              
+                  
             </span>
           </div>
           <div
@@ -2528,31 +3191,44 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
             <span
               class="name"
             >
+              
+                    
               <a
                 class="top-download-page"
                 href="http://puny-protocol.org"
                 rel="noopener"
                 target="_blank"
               >
-                architect visionary paradigms
+                
+                      architect visionary paradigms
+                    
               </a>
+              
+                  
             </span>
-             
+            
+                  
             <span
               class="domain"
             >
-              puny-protocol.org
+              
+                    puny-protocol.org
+                  
             </span>
-             
+            
+                  
             <span
               class="divider"
             >
               /
             </span>
-             
+            
+                  
             <span
               class="filename"
             >
+              
+                    
               <a
                 aria-label="around_psst.mid"
                 class="top-download-file"
@@ -2560,8 +3236,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
                 rel="noopener"
                 target="_blank"
               >
-                download file
+                
+                      download file
+                    
               </a>
+              
+                  
             </span>
           </div>
           <div
@@ -2583,31 +3263,44 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
             <span
               class="name"
             >
+              
+                    
               <a
                 class="top-download-page"
                 href="http://potable-cot.org"
                 rel="noopener"
                 target="_blank"
               >
-                enable e-business initiatives
+                
+                      enable e-business initiatives
+                    
               </a>
+              
+                  
             </span>
-             
+            
+                  
             <span
               class="domain"
             >
-              potable-cot.org
+              
+                    potable-cot.org
+                  
             </span>
-             
+            
+                  
             <span
               class="divider"
             >
               /
             </span>
-             
+            
+                  
             <span
               class="filename"
             >
+              
+                    
               <a
                 aria-label="per_furiously.odp"
                 class="top-download-file"
@@ -2615,8 +3308,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
                 rel="noopener"
                 target="_blank"
               >
-                download file
+                
+                      download file
+                    
               </a>
+              
+                  
             </span>
           </div>
           <div
@@ -2638,31 +3335,44 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
             <span
               class="name"
             >
+              
+                    
               <a
                 class="top-download-page"
                 href="http://creepy-yin.biz"
                 rel="noopener"
                 target="_blank"
               >
-                optimize enterprise metrics
+                
+                      optimize enterprise metrics
+                    
               </a>
+              
+                  
             </span>
-             
+            
+                  
             <span
               class="domain"
             >
-              creepy-yin.biz
+              
+                    creepy-yin.biz
+                  
             </span>
-             
+            
+                  
             <span
               class="divider"
             >
               /
             </span>
-             
+            
+                  
             <span
               class="filename"
             >
+              
+                    
               <a
                 aria-label="among_frightfully.m2a"
                 class="top-download-file"
@@ -2670,8 +3380,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
                 rel="noopener"
                 target="_blank"
               >
-                download file
+                
+                      download file
+                    
               </a>
+              
+                  
             </span>
           </div>
           <div
@@ -2693,31 +3407,44 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
             <span
               class="name"
             >
+              
+                    
               <a
                 class="top-download-page"
                 href="http://untried-morphology.net"
                 rel="noopener"
                 target="_blank"
               >
-                brand viral ROI
+                
+                      brand viral ROI
+                    
               </a>
+              
+                  
             </span>
-             
+            
+                  
             <span
               class="domain"
             >
-              untried-morphology.net
+              
+                    untried-morphology.net
+                  
             </span>
-             
+            
+                  
             <span
               class="divider"
             >
               /
             </span>
-             
+            
+                  
             <span
               class="filename"
             >
+              
+                    
               <a
                 aria-label="home_seemingly.map"
                 class="top-download-file"
@@ -2725,8 +3452,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
                 rel="noopener"
                 target="_blank"
               >
-                download file
+                
+                      download file
+                    
               </a>
+              
+                  
             </span>
           </div>
           <div
@@ -2748,31 +3479,44 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
             <span
               class="name"
             >
+              
+                    
               <a
                 class="top-download-page"
                 href="http://outstanding-apparatus.info"
                 rel="noopener"
                 target="_blank"
               >
-                aggregate efficient lifetime value
+                
+                      aggregate efficient lifetime value
+                    
               </a>
+              
+                  
             </span>
-             
+            
+                  
             <span
               class="domain"
             >
-              outstanding-apparatus.info
+              
+                    outstanding-apparatus.info
+                  
             </span>
-             
+            
+                  
             <span
               class="divider"
             >
               /
             </span>
-             
+            
+                  
             <span
               class="filename"
             >
+              
+                    
               <a
                 aria-label="macerate_zealous.rtf"
                 class="top-download-file"
@@ -2780,8 +3524,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
                 rel="noopener"
                 target="_blank"
               >
-                download file
+                
+                      download file
+                    
               </a>
+              
+                  
             </span>
           </div>
           <div
@@ -2803,31 +3551,44 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
             <span
               class="name"
             >
+              
+                    
               <a
                 class="top-download-page"
                 href="http://pointed-seller.org"
                 rel="noopener"
                 target="_blank"
               >
-                matrix intuitive networks
+                
+                      matrix intuitive networks
+                    
               </a>
+              
+                  
             </span>
-             
+            
+                  
             <span
               class="domain"
             >
-              pointed-seller.org
+              
+                    pointed-seller.org
+                  
             </span>
-             
+            
+                  
             <span
               class="divider"
             >
               /
             </span>
-             
+            
+                  
             <span
               class="filename"
             >
+              
+                    
               <a
                 aria-label="slate.zip"
                 class="top-download-file"
@@ -2835,8 +3596,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
                 rel="noopener"
                 target="_blank"
               >
-                download file
+                
+                      download file
+                    
               </a>
+              
+                  
             </span>
           </div>
           <div
@@ -2858,31 +3623,44 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
             <span
               class="name"
             >
+              
+                    
               <a
                 class="top-download-page"
                 href="http://respectful-upward.info"
                 rel="noopener"
                 target="_blank"
               >
-                streamline bleeding-edge functionalities
+                
+                      streamline bleeding-edge functionalities
+                    
               </a>
+              
+                  
             </span>
-             
+            
+                  
             <span
               class="domain"
             >
-              respectful-upward.info
+              
+                    respectful-upward.info
+                  
             </span>
-             
+            
+                  
             <span
               class="divider"
             >
               /
             </span>
-             
+            
+                  
             <span
               class="filename"
             >
+              
+                    
               <a
                 aria-label="gah_brutalize_definite.7z"
                 class="top-download-file"
@@ -2890,8 +3668,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
                 rel="noopener"
                 target="_blank"
               >
-                download file
+                
+                      download file
+                    
               </a>
+              
+                  
             </span>
           </div>
           <div
@@ -2913,31 +3695,44 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
             <span
               class="name"
             >
+              
+                    
               <a
                 class="top-download-page"
                 href="http://nice-nonsense.biz"
                 rel="noopener"
                 target="_blank"
               >
-                e-enable revolutionary web services
+                
+                      e-enable revolutionary web services
+                    
               </a>
+              
+                  
             </span>
-             
+            
+                  
             <span
               class="domain"
             >
-              nice-nonsense.biz
+              
+                    nice-nonsense.biz
+                  
             </span>
-             
+            
+                  
             <span
               class="divider"
             >
               /
             </span>
-             
+            
+                  
             <span
               class="filename"
             >
+              
+                    
               <a
                 aria-label="adventurously_note_incision.mp3"
                 class="top-download-file"
@@ -2945,8 +3740,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
                 rel="noopener"
                 target="_blank"
               >
-                download file
+                
+                      download file
+                    
               </a>
+              
+                  
             </span>
           </div>
           <div
@@ -2968,31 +3767,44 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
             <span
               class="name"
             >
+              
+                    
               <a
                 class="top-download-page"
                 href="http://voluminous-kale.name"
                 rel="noopener"
                 target="_blank"
               >
-                empower global infrastructures
+                
+                      empower global infrastructures
+                    
               </a>
+              
+                  
             </span>
-             
+            
+                  
             <span
               class="domain"
             >
-              voluminous-kale.name
+              
+                    voluminous-kale.name
+                  
             </span>
-             
+            
+                  
             <span
               class="divider"
             >
               /
             </span>
-             
+            
+                  
             <span
               class="filename"
             >
+              
+                    
               <a
                 aria-label="time_hiss_solidly.ogg"
                 class="top-download-file"
@@ -3000,8 +3812,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
                 rel="noopener"
                 target="_blank"
               >
-                download file
+                
+                      download file
+                    
               </a>
+              
+                  
             </span>
           </div>
           <div
@@ -3023,31 +3839,44 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
             <span
               class="name"
             >
+              
+                    
               <a
                 class="top-download-page"
                 href="http://black-and-white-plant.com"
                 rel="noopener"
                 target="_blank"
               >
-                brand revolutionary paradigms
+                
+                      brand revolutionary paradigms
+                    
               </a>
+              
+                  
             </span>
-             
+            
+                  
             <span
               class="domain"
             >
-              black-and-white-plant.com
+              
+                    black-and-white-plant.com
+                  
             </span>
-             
+            
+                  
             <span
               class="divider"
             >
               /
             </span>
-             
+            
+                  
             <span
               class="filename"
             >
+              
+                    
               <a
                 aria-label="brown_prostanoid.css"
                 class="top-download-file"
@@ -3055,8 +3884,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
                 rel="noopener"
                 target="_blank"
               >
-                download file
+                
+                      download file
+                    
               </a>
+              
+                  
             </span>
           </div>
           <div
@@ -3078,31 +3911,44 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
             <span
               class="name"
             >
+              
+                    
               <a
                 class="top-download-page"
                 href="http://biodegradable-consent.org"
                 rel="noopener"
                 target="_blank"
               >
-                utilize best-of-breed users
+                
+                      utilize best-of-breed users
+                    
               </a>
+              
+                  
             </span>
-             
+            
+                  
             <span
               class="domain"
             >
-              biodegradable-consent.org
+              
+                    biodegradable-consent.org
+                  
             </span>
-             
+            
+                  
             <span
               class="divider"
             >
               /
             </span>
-             
+            
+                  
             <span
               class="filename"
             >
+              
+                    
               <a
                 aria-label="um_punt_ugh.vsw"
                 class="top-download-file"
@@ -3110,8 +3956,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
                 rel="noopener"
                 target="_blank"
               >
-                download file
+                
+                      download file
+                    
               </a>
+              
+                  
             </span>
           </div>
           <div

--- a/js/components/dashboard_content/__tests__/__snapshots__/TopDownloadsAndVideoPlays.spec.js.snap
+++ b/js/components/dashboard_content/__tests__/__snapshots__/TopDownloadsAndVideoPlays.spec.js.snap
@@ -34,13 +34,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has >
             class="chart__bar-chart__item__label dark-grey text--overflow-ellipsis margin-right-8"
           >
             <span
-              class="name"
+              class="top-download__page-name"
             >
               
                     
               <a
-                class="top-download-page"
-                href="http://apt-metro.net"
+                href="http://frayed-bulb.com"
                 rel="noopener"
                 target="_blank"
               >
@@ -54,10 +53,10 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has >
             
                   
             <span
-              class="domain"
+              class="top-download__page-domain"
             >
               
-                    apt-metro.net
+                    frayed-bulb.com
                   
             </span>
             
@@ -70,14 +69,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has >
             
                   
             <span
-              class="filename"
+              class="top-download__file-location"
             >
               
                     
               <a
-                aria-label="pea_convict_alive.jsonld"
-                class="top-download-file"
-                href="https://apt-metro.netpea_convict_alive.jsonld"
+                href="https://whole-youth.info"
                 rel="noopener"
                 target="_blank"
               >
@@ -92,11 +89,11 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has >
           <div
             class="chart__bar-chart__item__value"
           >
-            9,667
+            2,002
           </div>
           <div
             class="chart__bar-chart__item__bar bg-light-blue"
-            style="width: 100%;"
+            style="width: 21%;"
           />
         </div>
         <div
@@ -106,13 +103,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has >
             class="chart__bar-chart__item__label dark-grey text--overflow-ellipsis margin-right-8"
           >
             <span
-              class="name"
+              class="top-download__page-name"
             >
               
                     
               <a
-                class="top-download-page"
-                href="http://drab-integer.org"
+                href="http://unfit-tune.info"
                 rel="noopener"
                 target="_blank"
               >
@@ -126,10 +122,10 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has >
             
                   
             <span
-              class="domain"
+              class="top-download__page-domain"
             >
               
-                    drab-integer.org
+                    unfit-tune.info
                   
             </span>
             
@@ -142,14 +138,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has >
             
                   
             <span
-              class="filename"
+              class="top-download__file-location"
             >
               
                     
               <a
-                aria-label="realistic_down_threadbare.midi"
-                class="top-download-file"
-                href="https://drab-integer.orgrealistic_down_threadbare.midi"
+                href="https://voluminous-consent.info"
                 rel="noopener"
                 target="_blank"
               >
@@ -164,11 +158,11 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has >
           <div
             class="chart__bar-chart__item__value"
           >
-            1,212
+            9,889
           </div>
           <div
             class="chart__bar-chart__item__bar bg-light-blue"
-            style="width: 13%;"
+            style="width: 100%;"
           />
         </div>
         <div
@@ -178,13 +172,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has >
             class="chart__bar-chart__item__label dark-grey text--overflow-ellipsis margin-right-8"
           >
             <span
-              class="name"
+              class="top-download__page-name"
             >
               
                     
               <a
-                class="top-download-page"
-                href="http://gruesome-command.org"
+                href="http://major-innocence.name"
                 rel="noopener"
                 target="_blank"
               >
@@ -198,10 +191,10 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has >
             
                   
             <span
-              class="domain"
+              class="top-download__page-domain"
             >
               
-                    gruesome-command.org
+                    major-innocence.name
                   
             </span>
             
@@ -214,14 +207,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has >
             
                   
             <span
-              class="filename"
+              class="top-download__file-location"
             >
               
                     
               <a
-                aria-label="crime_outside.bz"
-                class="top-download-file"
-                href="https://gruesome-command.orgcrime_outside.bz"
+                href="https://official-descent.name"
                 rel="noopener"
                 target="_blank"
               >
@@ -236,11 +227,11 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has >
           <div
             class="chart__bar-chart__item__value"
           >
-            1,322
+            3,671
           </div>
           <div
             class="chart__bar-chart__item__bar bg-light-blue"
-            style="width: 15%;"
+            style="width: 38%;"
           />
         </div>
         <div
@@ -250,13 +241,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has >
             class="chart__bar-chart__item__label dark-grey text--overflow-ellipsis margin-right-8"
           >
             <span
-              class="name"
+              class="top-download__page-name"
             >
               
                     
               <a
-                class="top-download-page"
-                href="http://remarkable-gateway.info"
+                href="http://favorite-dune.org"
                 rel="noopener"
                 target="_blank"
               >
@@ -270,10 +260,10 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has >
             
                   
             <span
-              class="domain"
+              class="top-download__page-domain"
             >
               
-                    remarkable-gateway.info
+                    favorite-dune.org
                   
             </span>
             
@@ -286,14 +276,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has >
             
                   
             <span
-              class="filename"
+              class="top-download__file-location"
             >
               
                     
               <a
-                aria-label="ack.msi"
-                class="top-download-file"
-                href="https://remarkable-gateway.infoack.msi"
+                href="https://forthright-pause.org"
                 rel="noopener"
                 target="_blank"
               >
@@ -308,11 +296,11 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has >
           <div
             class="chart__bar-chart__item__value"
           >
-            9,573
+            3,487
           </div>
           <div
             class="chart__bar-chart__item__bar bg-light-blue"
-            style="width: 99%;"
+            style="width: 36%;"
           />
         </div>
         <div
@@ -322,13 +310,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has >
             class="chart__bar-chart__item__label dark-grey text--overflow-ellipsis margin-right-8"
           >
             <span
-              class="name"
+              class="top-download__page-name"
             >
               
                     
               <a
-                class="top-download-page"
-                href="http://incomparable-corporation.org"
+                href="http://criminal-futon.biz"
                 rel="noopener"
                 target="_blank"
               >
@@ -342,10 +329,10 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has >
             
                   
             <span
-              class="domain"
+              class="top-download__page-domain"
             >
               
-                    incomparable-corporation.org
+                    criminal-futon.biz
                   
             </span>
             
@@ -358,14 +345,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has >
             
                   
             <span
-              class="filename"
+              class="top-download__file-location"
             >
               
                     
               <a
-                aria-label="atop_psst.pps"
-                class="top-download-file"
-                href="https://incomparable-corporation.orgatop_psst.pps"
+                href="https://kaleidoscopic-oatmeal.info"
                 rel="noopener"
                 target="_blank"
               >
@@ -380,11 +365,11 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has >
           <div
             class="chart__bar-chart__item__value"
           >
-            1,329
+            7,353
           </div>
           <div
             class="chart__bar-chart__item__bar bg-light-blue"
-            style="width: 15%;"
+            style="width: 75%;"
           />
         </div>
         <div
@@ -394,13 +379,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has >
             class="chart__bar-chart__item__label dark-grey text--overflow-ellipsis margin-right-8"
           >
             <span
-              class="name"
+              class="top-download__page-name"
             >
               
                     
               <a
-                class="top-download-page"
-                href="http://dapper-espalier.info"
+                href="http://stark-iris.org"
                 rel="noopener"
                 target="_blank"
               >
@@ -414,10 +398,10 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has >
             
                   
             <span
-              class="domain"
+              class="top-download__page-domain"
             >
               
-                    dapper-espalier.info
+                    stark-iris.org
                   
             </span>
             
@@ -430,14 +414,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has >
             
                   
             <span
-              class="filename"
+              class="top-download__file-location"
             >
               
                     
               <a
-                aria-label="judicious_or.pptx"
-                class="top-download-file"
-                href="https://dapper-espalier.infojudicious_or.pptx"
+                href="https://plain-citrus.org"
                 rel="noopener"
                 target="_blank"
               >
@@ -452,11 +434,11 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has >
           <div
             class="chart__bar-chart__item__value"
           >
-            8,748
+            6,703
           </div>
           <div
             class="chart__bar-chart__item__bar bg-light-blue"
-            style="width: 91%;"
+            style="width: 68%;"
           />
         </div>
         <div
@@ -466,13 +448,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has >
             class="chart__bar-chart__item__label dark-grey text--overflow-ellipsis margin-right-8"
           >
             <span
-              class="name"
+              class="top-download__page-name"
             >
               
                     
               <a
-                class="top-download-page"
-                href="http://imaginative-soy.biz"
+                href="http://perfect-reveal.org"
                 rel="noopener"
                 target="_blank"
               >
@@ -486,10 +467,10 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has >
             
                   
             <span
-              class="domain"
+              class="top-download__page-domain"
             >
               
-                    imaginative-soy.biz
+                    perfect-reveal.org
                   
             </span>
             
@@ -502,14 +483,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has >
             
                   
             <span
-              class="filename"
+              class="top-download__file-location"
             >
               
                     
               <a
-                aria-label="failing_modulate.txt"
-                class="top-download-file"
-                href="https://imaginative-soy.bizfailing_modulate.txt"
+                href="https://hard-to-find-vet.biz"
                 rel="noopener"
                 target="_blank"
               >
@@ -524,11 +503,11 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has >
           <div
             class="chart__bar-chart__item__value"
           >
-            462
+            2,532
           </div>
           <div
             class="chart__bar-chart__item__bar bg-light-blue"
-            style="width: 6%;"
+            style="width: 26%;"
           />
         </div>
         <div
@@ -538,13 +517,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has >
             class="chart__bar-chart__item__label dark-grey text--overflow-ellipsis margin-right-8"
           >
             <span
-              class="name"
+              class="top-download__page-name"
             >
               
                     
               <a
-                class="top-download-page"
-                href="http://juvenile-earthquake.name"
+                href="http://low-superiority.com"
                 rel="noopener"
                 target="_blank"
               >
@@ -558,10 +536,10 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has >
             
                   
             <span
-              class="domain"
+              class="top-download__page-domain"
             >
               
-                    juvenile-earthquake.name
+                    low-superiority.com
                   
             </span>
             
@@ -574,14 +552,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has >
             
                   
             <span
-              class="filename"
+              class="top-download__file-location"
             >
               
                     
               <a
-                aria-label="awake_with_petition.xht"
-                class="top-download-file"
-                href="https://juvenile-earthquake.nameawake_with_petition.xht"
+                href="https://sure-footed-part.biz"
                 rel="noopener"
                 target="_blank"
               >
@@ -596,11 +572,11 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has >
           <div
             class="chart__bar-chart__item__value"
           >
-            5,023
+            6,477
           </div>
           <div
             class="chart__bar-chart__item__bar bg-light-blue"
-            style="width: 52%;"
+            style="width: 66%;"
           />
         </div>
         <div
@@ -610,13 +586,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has >
             class="chart__bar-chart__item__label dark-grey text--overflow-ellipsis margin-right-8"
           >
             <span
-              class="name"
+              class="top-download__page-name"
             >
               
                     
               <a
-                class="top-download-page"
-                href="http://equal-bronze.com"
+                href="http://outgoing-fraction.com"
                 rel="noopener"
                 target="_blank"
               >
@@ -630,10 +605,10 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has >
             
                   
             <span
-              class="domain"
+              class="top-download__page-domain"
             >
               
-                    equal-bronze.com
+                    outgoing-fraction.com
                   
             </span>
             
@@ -646,14 +621,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has >
             
                   
             <span
-              class="filename"
+              class="top-download__file-location"
             >
               
                     
               <a
-                aria-label="yowza_although.ogg"
-                class="top-download-file"
-                href="https://equal-bronze.comyowza_although.ogg"
+                href="https://judicious-universe.com"
                 rel="noopener"
                 target="_blank"
               >
@@ -668,11 +641,11 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has >
           <div
             class="chart__bar-chart__item__value"
           >
-            1,380
+            282
           </div>
           <div
             class="chart__bar-chart__item__bar bg-light-blue"
-            style="width: 15%;"
+            style="width: 4%;"
           />
         </div>
         <div
@@ -682,13 +655,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has >
             class="chart__bar-chart__item__label dark-grey text--overflow-ellipsis margin-right-8"
           >
             <span
-              class="name"
+              class="top-download__page-name"
             >
               
                     
               <a
-                class="top-download-page"
-                href="http://innocent-bail.name"
+                href="http://ambitious-venture.biz"
                 rel="noopener"
                 target="_blank"
               >
@@ -702,10 +674,10 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has >
             
                   
             <span
-              class="domain"
+              class="top-download__page-domain"
             >
               
-                    innocent-bail.name
+                    ambitious-venture.biz
                   
             </span>
             
@@ -718,14 +690,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has >
             
                   
             <span
-              class="filename"
+              class="top-download__file-location"
             >
               
                     
               <a
-                aria-label="by_boohoo.list"
-                class="top-download-file"
-                href="https://innocent-bail.nameby_boohoo.list"
+                href="https://high-invention.info"
                 rel="noopener"
                 target="_blank"
               >
@@ -740,11 +710,11 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has >
           <div
             class="chart__bar-chart__item__value"
           >
-            4,697
+            6,353
           </div>
           <div
             class="chart__bar-chart__item__bar bg-light-blue"
-            style="width: 49%;"
+            style="width: 65%;"
           />
         </div>
       </div>
@@ -1051,13 +1021,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has 2
             class="chart__bar-chart__item__label dark-grey text--overflow-ellipsis margin-right-8"
           >
             <span
-              class="name"
+              class="top-download__page-name"
             >
               
                     
               <a
-                class="top-download-page"
-                href="http://healthy-wedding.com"
+                href="http://bright-monotheism.net"
                 rel="noopener"
                 target="_blank"
               >
@@ -1071,10 +1040,10 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has 2
             
                   
             <span
-              class="domain"
+              class="top-download__page-domain"
             >
               
-                    healthy-wedding.com
+                    bright-monotheism.net
                   
             </span>
             
@@ -1087,14 +1056,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has 2
             
                   
             <span
-              class="filename"
+              class="top-download__file-location"
             >
               
                     
               <a
-                aria-label="grate.dist"
-                class="top-download-file"
-                href="https://healthy-wedding.comgrate.dist"
+                href="https://flawless-naturalisation.info"
                 rel="noopener"
                 target="_blank"
               >
@@ -1109,11 +1076,11 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has 2
           <div
             class="chart__bar-chart__item__value"
           >
-            8,270
+            7,269
           </div>
           <div
             class="chart__bar-chart__item__bar bg-light-blue"
-            style="width: 84%;"
+            style="width: 75%;"
           />
         </div>
         <div
@@ -1123,13 +1090,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has 2
             class="chart__bar-chart__item__label dark-grey text--overflow-ellipsis margin-right-8"
           >
             <span
-              class="name"
+              class="top-download__page-name"
             >
               
                     
               <a
-                class="top-download-page"
-                href="http://grandiose-maker.info"
+                href="http://admirable-art.org"
                 rel="noopener"
                 target="_blank"
               >
@@ -1143,10 +1109,10 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has 2
             
                   
             <span
-              class="domain"
+              class="top-download__page-domain"
             >
               
-                    grandiose-maker.info
+                    admirable-art.org
                   
             </span>
             
@@ -1159,14 +1125,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has 2
             
                   
             <span
-              class="filename"
+              class="top-download__file-location"
             >
               
                     
               <a
-                aria-label="tremendously_foolishly_considerate.mp2a"
-                class="top-download-file"
-                href="https://grandiose-maker.infotremendously_foolishly_considerate.mp2a"
+                href="https://rigid-oboe.name"
                 rel="noopener"
                 target="_blank"
               >
@@ -1181,583 +1145,7 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has 2
           <div
             class="chart__bar-chart__item__value"
           >
-            635
-          </div>
-          <div
-            class="chart__bar-chart__item__bar bg-light-blue"
-            style="width: 7%;"
-          />
-        </div>
-        <div
-          class="chart__bar-chart__item"
-        >
-          <div
-            class="chart__bar-chart__item__label dark-grey text--overflow-ellipsis margin-right-8"
-          >
-            <span
-              class="name"
-            >
-              
-                    
-              <a
-                class="top-download-page"
-                href="http://demanding-clipboard.info"
-                rel="noopener"
-                target="_blank"
-              >
-                
-                      mesh innovative mindshare
-                    
-              </a>
-              
-                  
-            </span>
-            
-                  
-            <span
-              class="domain"
-            >
-              
-                    demanding-clipboard.info
-                  
-            </span>
-            
-                  
-            <span
-              class="divider"
-            >
-              /
-            </span>
-            
-                  
-            <span
-              class="filename"
-            >
-              
-                    
-              <a
-                aria-label="discard_minus.mp2"
-                class="top-download-file"
-                href="https://demanding-clipboard.infodiscard_minus.mp2"
-                rel="noopener"
-                target="_blank"
-              >
-                
-                      download file
-                    
-              </a>
-              
-                  
-            </span>
-          </div>
-          <div
-            class="chart__bar-chart__item__value"
-          >
-            2,948
-          </div>
-          <div
-            class="chart__bar-chart__item__bar bg-light-blue"
-            style="width: 31%;"
-          />
-        </div>
-        <div
-          class="chart__bar-chart__item"
-        >
-          <div
-            class="chart__bar-chart__item__label dark-grey text--overflow-ellipsis margin-right-8"
-          >
-            <span
-              class="name"
-            >
-              
-                    
-              <a
-                class="top-download-page"
-                href="http://rotten-dad.info"
-                rel="noopener"
-                target="_blank"
-              >
-                
-                      seize real-time technologies
-                    
-              </a>
-              
-                  
-            </span>
-            
-                  
-            <span
-              class="domain"
-            >
-              
-                    rotten-dad.info
-                  
-            </span>
-            
-                  
-            <span
-              class="divider"
-            >
-              /
-            </span>
-            
-                  
-            <span
-              class="filename"
-            >
-              
-                    
-              <a
-                aria-label="up_grace_doubtfully.m2v"
-                class="top-download-file"
-                href="https://rotten-dad.infoup_grace_doubtfully.m2v"
-                rel="noopener"
-                target="_blank"
-              >
-                
-                      download file
-                    
-              </a>
-              
-                  
-            </span>
-          </div>
-          <div
-            class="chart__bar-chart__item__value"
-          >
-            7,945
-          </div>
-          <div
-            class="chart__bar-chart__item__bar bg-light-blue"
-            style="width: 81%;"
-          />
-        </div>
-        <div
-          class="chart__bar-chart__item"
-        >
-          <div
-            class="chart__bar-chart__item__label dark-grey text--overflow-ellipsis margin-right-8"
-          >
-            <span
-              class="name"
-            >
-              
-                    
-              <a
-                class="top-download-page"
-                href="http://conscious-chord.com"
-                rel="noopener"
-                target="_blank"
-              >
-                
-                      utilize revolutionary users
-                    
-              </a>
-              
-                  
-            </span>
-            
-                  
-            <span
-              class="domain"
-            >
-              
-                    conscious-chord.com
-                  
-            </span>
-            
-                  
-            <span
-              class="divider"
-            >
-              /
-            </span>
-            
-                  
-            <span
-              class="filename"
-            >
-              
-                    
-              <a
-                aria-label="per.ini"
-                class="top-download-file"
-                href="https://conscious-chord.comper.ini"
-                rel="noopener"
-                target="_blank"
-              >
-                
-                      download file
-                    
-              </a>
-              
-                  
-            </span>
-          </div>
-          <div
-            class="chart__bar-chart__item__value"
-          >
-            4,884
-          </div>
-          <div
-            class="chart__bar-chart__item__bar bg-light-blue"
-            style="width: 50%;"
-          />
-        </div>
-        <div
-          class="chart__bar-chart__item"
-        >
-          <div
-            class="chart__bar-chart__item__label dark-grey text--overflow-ellipsis margin-right-8"
-          >
-            <span
-              class="name"
-            >
-              
-                    
-              <a
-                class="top-download-page"
-                href="http://strong-burn-out.com"
-                rel="noopener"
-                target="_blank"
-              >
-                
-                      scale magnetic metrics
-                    
-              </a>
-              
-                  
-            </span>
-            
-                  
-            <span
-              class="domain"
-            >
-              
-                    strong-burn-out.com
-                  
-            </span>
-            
-                  
-            <span
-              class="divider"
-            >
-              /
-            </span>
-            
-                  
-            <span
-              class="filename"
-            >
-              
-                    
-              <a
-                aria-label="hastily.dll"
-                class="top-download-file"
-                href="https://strong-burn-out.comhastily.dll"
-                rel="noopener"
-                target="_blank"
-              >
-                
-                      download file
-                    
-              </a>
-              
-                  
-            </span>
-          </div>
-          <div
-            class="chart__bar-chart__item__value"
-          >
-            2,680
-          </div>
-          <div
-            class="chart__bar-chart__item__bar bg-light-blue"
-            style="width: 28%;"
-          />
-        </div>
-        <div
-          class="chart__bar-chart__item"
-        >
-          <div
-            class="chart__bar-chart__item__label dark-grey text--overflow-ellipsis margin-right-8"
-          >
-            <span
-              class="name"
-            >
-              
-                    
-              <a
-                class="top-download-page"
-                href="http://wasteful-temptation.biz"
-                rel="noopener"
-                target="_blank"
-              >
-                
-                      facilitate back-end solutions
-                    
-              </a>
-              
-                  
-            </span>
-            
-                  
-            <span
-              class="domain"
-            >
-              
-                    wasteful-temptation.biz
-                  
-            </span>
-            
-                  
-            <span
-              class="divider"
-            >
-              /
-            </span>
-            
-                  
-            <span
-              class="filename"
-            >
-              
-                    
-              <a
-                aria-label="casket.webm"
-                class="top-download-file"
-                href="https://wasteful-temptation.bizcasket.webm"
-                rel="noopener"
-                target="_blank"
-              >
-                
-                      download file
-                    
-              </a>
-              
-                  
-            </span>
-          </div>
-          <div
-            class="chart__bar-chart__item__value"
-          >
-            9,104
-          </div>
-          <div
-            class="chart__bar-chart__item__bar bg-light-blue"
-            style="width: 92%;"
-          />
-        </div>
-        <div
-          class="chart__bar-chart__item"
-        >
-          <div
-            class="chart__bar-chart__item__label dark-grey text--overflow-ellipsis margin-right-8"
-          >
-            <span
-              class="name"
-            >
-              
-                    
-              <a
-                class="top-download-page"
-                href="http://sore-event.name"
-                rel="noopener"
-                target="_blank"
-              >
-                
-                      streamline global ROI
-                    
-              </a>
-              
-                  
-            </span>
-            
-                  
-            <span
-              class="domain"
-            >
-              
-                    sore-event.name
-                  
-            </span>
-            
-                  
-            <span
-              class="divider"
-            >
-              /
-            </span>
-            
-                  
-            <span
-              class="filename"
-            >
-              
-                    
-              <a
-                aria-label="author_regale_describe.js"
-                class="top-download-file"
-                href="https://sore-event.nameauthor_regale_describe.js"
-                rel="noopener"
-                target="_blank"
-              >
-                
-                      download file
-                    
-              </a>
-              
-                  
-            </span>
-          </div>
-          <div
-            class="chart__bar-chart__item__value"
-          >
-            2,878
-          </div>
-          <div
-            class="chart__bar-chart__item__bar bg-light-blue"
-            style="width: 30%;"
-          />
-        </div>
-        <div
-          class="chart__bar-chart__item"
-        >
-          <div
-            class="chart__bar-chart__item__label dark-grey text--overflow-ellipsis margin-right-8"
-          >
-            <span
-              class="name"
-            >
-              
-                    
-              <a
-                class="top-download-page"
-                href="http://plush-company.info"
-                rel="noopener"
-                target="_blank"
-              >
-                
-                      engage transparent initiatives
-                    
-              </a>
-              
-                  
-            </span>
-            
-                  
-            <span
-              class="domain"
-            >
-              
-                    plush-company.info
-                  
-            </span>
-            
-                  
-            <span
-              class="divider"
-            >
-              /
-            </span>
-            
-                  
-            <span
-              class="filename"
-            >
-              
-                    
-              <a
-                aria-label="clearly.bpk"
-                class="top-download-file"
-                href="https://plush-company.infoclearly.bpk"
-                rel="noopener"
-                target="_blank"
-              >
-                
-                      download file
-                    
-              </a>
-              
-                  
-            </span>
-          </div>
-          <div
-            class="chart__bar-chart__item__value"
-          >
-            5,638
-          </div>
-          <div
-            class="chart__bar-chart__item__bar bg-light-blue"
-            style="width: 58%;"
-          />
-        </div>
-        <div
-          class="chart__bar-chart__item"
-        >
-          <div
-            class="chart__bar-chart__item__label dark-grey text--overflow-ellipsis margin-right-8"
-          >
-            <span
-              class="name"
-            >
-              
-                    
-              <a
-                class="top-download-page"
-                href="http://outstanding-mouth.biz"
-                rel="noopener"
-                target="_blank"
-              >
-                
-                      enable customized solutions
-                    
-              </a>
-              
-                  
-            </span>
-            
-                  
-            <span
-              class="domain"
-            >
-              
-                    outstanding-mouth.biz
-                  
-            </span>
-            
-                  
-            <span
-              class="divider"
-            >
-              /
-            </span>
-            
-                  
-            <span
-              class="filename"
-            >
-              
-                    
-              <a
-                aria-label="how_filter.mp4v"
-                class="top-download-file"
-                href="https://outstanding-mouth.bizhow_filter.mp4v"
-                rel="noopener"
-                target="_blank"
-              >
-                
-                      download file
-                    
-              </a>
-              
-                  
-            </span>
-          </div>
-          <div
-            class="chart__bar-chart__item__value"
-          >
-            1,262
+            1,243
           </div>
           <div
             class="chart__bar-chart__item__bar bg-light-blue"
@@ -1771,18 +1159,17 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has 2
             class="chart__bar-chart__item__label dark-grey text--overflow-ellipsis margin-right-8"
           >
             <span
-              class="name"
+              class="top-download__page-name"
             >
               
                     
               <a
-                class="top-download-page"
-                href="http://doting-drizzle.name"
+                href="http://whimsical-pipe.com"
                 rel="noopener"
                 target="_blank"
               >
                 
-                      monetize extensible initiatives
+                      mesh innovative mindshare
                     
               </a>
               
@@ -1791,10 +1178,10 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has 2
             
                   
             <span
-              class="domain"
+              class="top-download__page-domain"
             >
               
-                    doting-drizzle.name
+                    whimsical-pipe.com
                   
             </span>
             
@@ -1807,14 +1194,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has 2
             
                   
             <span
-              class="filename"
+              class="top-download__file-location"
             >
               
                     
               <a
-                aria-label="kind_nearer_although.dist"
-                class="top-download-file"
-                href="https://doting-drizzle.namekind_nearer_although.dist"
+                href="https://posh-dialogue.org"
                 rel="noopener"
                 target="_blank"
               >
@@ -1829,7 +1214,283 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has 2
           <div
             class="chart__bar-chart__item__value"
           >
-            5,981
+            4,132
+          </div>
+          <div
+            class="chart__bar-chart__item__bar bg-light-blue"
+            style="width: 43%;"
+          />
+        </div>
+        <div
+          class="chart__bar-chart__item"
+        >
+          <div
+            class="chart__bar-chart__item__label dark-grey text--overflow-ellipsis margin-right-8"
+          >
+            <span
+              class="top-download__page-name"
+            >
+              
+                    
+              <a
+                href="http://ringed-sweatsuit.net"
+                rel="noopener"
+                target="_blank"
+              >
+                
+                      seize real-time technologies
+                    
+              </a>
+              
+                  
+            </span>
+            
+                  
+            <span
+              class="top-download__page-domain"
+            >
+              
+                    ringed-sweatsuit.net
+                  
+            </span>
+            
+                  
+            <span
+              class="divider"
+            >
+              /
+            </span>
+            
+                  
+            <span
+              class="top-download__file-location"
+            >
+              
+                    
+              <a
+                href="https://thunderous-provider.biz"
+                rel="noopener"
+                target="_blank"
+              >
+                
+                      download file
+                    
+              </a>
+              
+                  
+            </span>
+          </div>
+          <div
+            class="chart__bar-chart__item__value"
+          >
+            308
+          </div>
+          <div
+            class="chart__bar-chart__item__bar bg-light-blue"
+            style="width: 4%;"
+          />
+        </div>
+        <div
+          class="chart__bar-chart__item"
+        >
+          <div
+            class="chart__bar-chart__item__label dark-grey text--overflow-ellipsis margin-right-8"
+          >
+            <span
+              class="top-download__page-name"
+            >
+              
+                    
+              <a
+                href="http://pointed-necktie.info"
+                rel="noopener"
+                target="_blank"
+              >
+                
+                      utilize revolutionary users
+                    
+              </a>
+              
+                  
+            </span>
+            
+                  
+            <span
+              class="top-download__page-domain"
+            >
+              
+                    pointed-necktie.info
+                  
+            </span>
+            
+                  
+            <span
+              class="divider"
+            >
+              /
+            </span>
+            
+                  
+            <span
+              class="top-download__file-location"
+            >
+              
+                    
+              <a
+                href="https://deficient-burrito.net"
+                rel="noopener"
+                target="_blank"
+              >
+                
+                      download file
+                    
+              </a>
+              
+                  
+            </span>
+          </div>
+          <div
+            class="chart__bar-chart__item__value"
+          >
+            2,825
+          </div>
+          <div
+            class="chart__bar-chart__item__bar bg-light-blue"
+            style="width: 30%;"
+          />
+        </div>
+        <div
+          class="chart__bar-chart__item"
+        >
+          <div
+            class="chart__bar-chart__item__label dark-grey text--overflow-ellipsis margin-right-8"
+          >
+            <span
+              class="top-download__page-name"
+            >
+              
+                    
+              <a
+                href="http://quarterly-stallion.org"
+                rel="noopener"
+                target="_blank"
+              >
+                
+                      scale magnetic metrics
+                    
+              </a>
+              
+                  
+            </span>
+            
+                  
+            <span
+              class="top-download__page-domain"
+            >
+              
+                    quarterly-stallion.org
+                  
+            </span>
+            
+                  
+            <span
+              class="divider"
+            >
+              /
+            </span>
+            
+                  
+            <span
+              class="top-download__file-location"
+            >
+              
+                    
+              <a
+                href="https://bold-sorbet.com"
+                rel="noopener"
+                target="_blank"
+              >
+                
+                      download file
+                    
+              </a>
+              
+                  
+            </span>
+          </div>
+          <div
+            class="chart__bar-chart__item__value"
+          >
+            4,009
+          </div>
+          <div
+            class="chart__bar-chart__item__bar bg-light-blue"
+            style="width: 42%;"
+          />
+        </div>
+        <div
+          class="chart__bar-chart__item"
+        >
+          <div
+            class="chart__bar-chart__item__label dark-grey text--overflow-ellipsis margin-right-8"
+          >
+            <span
+              class="top-download__page-name"
+            >
+              
+                    
+              <a
+                href="http://scornful-behest.info"
+                rel="noopener"
+                target="_blank"
+              >
+                
+                      facilitate back-end solutions
+                    
+              </a>
+              
+                  
+            </span>
+            
+                  
+            <span
+              class="top-download__page-domain"
+            >
+              
+                    scornful-behest.info
+                  
+            </span>
+            
+                  
+            <span
+              class="divider"
+            >
+              /
+            </span>
+            
+                  
+            <span
+              class="top-download__file-location"
+            >
+              
+                    
+              <a
+                href="https://embarrassed-boxspring.com"
+                rel="noopener"
+                target="_blank"
+              >
+                
+                      download file
+                    
+              </a>
+              
+                  
+            </span>
+          </div>
+          <div
+            class="chart__bar-chart__item__value"
+          >
+            5,914
           </div>
           <div
             class="chart__bar-chart__item__bar bg-light-blue"
@@ -1843,18 +1504,17 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has 2
             class="chart__bar-chart__item__label dark-grey text--overflow-ellipsis margin-right-8"
           >
             <span
-              class="name"
+              class="top-download__page-name"
             >
               
                     
               <a
-                class="top-download-page"
-                href="http://honored-freak.name"
+                href="http://emotional-custard.net"
                 rel="noopener"
                 target="_blank"
               >
                 
-                      implement clicks-and-mortar e-commerce
+                      streamline global ROI
                     
               </a>
               
@@ -1863,10 +1523,10 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has 2
             
                   
             <span
-              class="domain"
+              class="top-download__page-domain"
             >
               
-                    honored-freak.name
+                    emotional-custard.net
                   
             </span>
             
@@ -1879,14 +1539,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has 2
             
                   
             <span
-              class="filename"
+              class="top-download__file-location"
             >
               
                     
               <a
-                aria-label="original_but.m2a"
-                class="top-download-file"
-                href="https://honored-freak.nameoriginal_but.m2a"
+                href="https://urban-happening.name"
                 rel="noopener"
                 target="_blank"
               >
@@ -1901,11 +1559,11 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has 2
           <div
             class="chart__bar-chart__item__value"
           >
-            3,477
+            3,016
           </div>
           <div
             class="chart__bar-chart__item__bar bg-light-blue"
-            style="width: 36%;"
+            style="width: 32%;"
           />
         </div>
         <div
@@ -1915,18 +1573,17 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has 2
             class="chart__bar-chart__item__label dark-grey text--overflow-ellipsis margin-right-8"
           >
             <span
-              class="name"
+              class="top-download__page-name"
             >
               
                     
               <a
-                class="top-download-page"
-                href="http://true-glockenspiel.name"
+                href="http://nervous-recipient.com"
                 rel="noopener"
                 target="_blank"
               >
                 
-                      synergize best-of-breed schemas
+                      engage transparent initiatives
                     
               </a>
               
@@ -1935,10 +1592,10 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has 2
             
                   
             <span
-              class="domain"
+              class="top-download__page-domain"
             >
               
-                    true-glockenspiel.name
+                    nervous-recipient.com
                   
             </span>
             
@@ -1951,14 +1608,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has 2
             
                   
             <span
-              class="filename"
+              class="top-download__file-location"
             >
               
                     
               <a
-                aria-label="ha_translate_after.distz"
-                class="top-download-file"
-                href="https://true-glockenspiel.nameha_translate_after.distz"
+                href="https://advanced-environment.name"
                 rel="noopener"
                 target="_blank"
               >
@@ -1973,439 +1628,7 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has 2
           <div
             class="chart__bar-chart__item__value"
           >
-            4,499
-          </div>
-          <div
-            class="chart__bar-chart__item__bar bg-light-blue"
-            style="width: 46%;"
-          />
-        </div>
-        <div
-          class="chart__bar-chart__item"
-        >
-          <div
-            class="chart__bar-chart__item__label dark-grey text--overflow-ellipsis margin-right-8"
-          >
-            <span
-              class="name"
-            >
-              
-                    
-              <a
-                class="top-download-page"
-                href="http://tart-relay.org"
-                rel="noopener"
-                target="_blank"
-              >
-                
-                      harness one-to-one solutions
-                    
-              </a>
-              
-                  
-            </span>
-            
-                  
-            <span
-              class="domain"
-            >
-              
-                    tart-relay.org
-                  
-            </span>
-            
-                  
-            <span
-              class="divider"
-            >
-              /
-            </span>
-            
-                  
-            <span
-              class="filename"
-            >
-              
-                    
-              <a
-                aria-label="sanction_ew_glorious.xul"
-                class="top-download-file"
-                href="https://tart-relay.orgsanction_ew_glorious.xul"
-                rel="noopener"
-                target="_blank"
-              >
-                
-                      download file
-                    
-              </a>
-              
-                  
-            </span>
-          </div>
-          <div
-            class="chart__bar-chart__item__value"
-          >
-            9,852
-          </div>
-          <div
-            class="chart__bar-chart__item__bar bg-light-blue"
-            style="width: 100%;"
-          />
-        </div>
-        <div
-          class="chart__bar-chart__item"
-        >
-          <div
-            class="chart__bar-chart__item__label dark-grey text--overflow-ellipsis margin-right-8"
-          >
-            <span
-              class="name"
-            >
-              
-                    
-              <a
-                class="top-download-page"
-                href="http://spirited-sanctuary.biz"
-                rel="noopener"
-                target="_blank"
-              >
-                
-                      morph e-business technologies
-                    
-              </a>
-              
-                  
-            </span>
-            
-                  
-            <span
-              class="domain"
-            >
-              
-                    spirited-sanctuary.biz
-                  
-            </span>
-            
-                  
-            <span
-              class="divider"
-            >
-              /
-            </span>
-            
-                  
-            <span
-              class="filename"
-            >
-              
-                    
-              <a
-                aria-label="vivid_elk_sleepy.midi"
-                class="top-download-file"
-                href="https://spirited-sanctuary.bizvivid_elk_sleepy.midi"
-                rel="noopener"
-                target="_blank"
-              >
-                
-                      download file
-                    
-              </a>
-              
-                  
-            </span>
-          </div>
-          <div
-            class="chart__bar-chart__item__value"
-          >
-            6,688
-          </div>
-          <div
-            class="chart__bar-chart__item__bar bg-light-blue"
-            style="width: 68%;"
-          />
-        </div>
-        <div
-          class="chart__bar-chart__item"
-        >
-          <div
-            class="chart__bar-chart__item__label dark-grey text--overflow-ellipsis margin-right-8"
-          >
-            <span
-              class="name"
-            >
-              
-                    
-              <a
-                class="top-download-page"
-                href="http://hilarious-destiny.info"
-                rel="noopener"
-                target="_blank"
-              >
-                
-                      engage web-enabled functionalities
-                    
-              </a>
-              
-                  
-            </span>
-            
-                  
-            <span
-              class="domain"
-            >
-              
-                    hilarious-destiny.info
-                  
-            </span>
-            
-                  
-            <span
-              class="divider"
-            >
-              /
-            </span>
-            
-                  
-            <span
-              class="filename"
-            >
-              
-                    
-              <a
-                aria-label="emphasize_psst.pps"
-                class="top-download-file"
-                href="https://hilarious-destiny.infoemphasize_psst.pps"
-                rel="noopener"
-                target="_blank"
-              >
-                
-                      download file
-                    
-              </a>
-              
-                  
-            </span>
-          </div>
-          <div
-            class="chart__bar-chart__item__value"
-          >
-            9,811
-          </div>
-          <div
-            class="chart__bar-chart__item__bar bg-light-blue"
-            style="width: 100%;"
-          />
-        </div>
-        <div
-          class="chart__bar-chart__item"
-        >
-          <div
-            class="chart__bar-chart__item__label dark-grey text--overflow-ellipsis margin-right-8"
-          >
-            <span
-              class="name"
-            >
-              
-                    
-              <a
-                class="top-download-page"
-                href="http://intent-elbow.net"
-                rel="noopener"
-                target="_blank"
-              >
-                
-                      seize viral solutions
-                    
-              </a>
-              
-                  
-            </span>
-            
-                  
-            <span
-              class="domain"
-            >
-              
-                    intent-elbow.net
-                  
-            </span>
-            
-                  
-            <span
-              class="divider"
-            >
-              /
-            </span>
-            
-                  
-            <span
-              class="filename"
-            >
-              
-                    
-              <a
-                aria-label="regarding_retention.zip"
-                class="top-download-file"
-                href="https://intent-elbow.netregarding_retention.zip"
-                rel="noopener"
-                target="_blank"
-              >
-                
-                      download file
-                    
-              </a>
-              
-                  
-            </span>
-          </div>
-          <div
-            class="chart__bar-chart__item__value"
-          >
-            4,782
-          </div>
-          <div
-            class="chart__bar-chart__item__bar bg-light-blue"
-            style="width: 49%;"
-          />
-        </div>
-        <div
-          class="chart__bar-chart__item"
-        >
-          <div
-            class="chart__bar-chart__item__label dark-grey text--overflow-ellipsis margin-right-8"
-          >
-            <span
-              class="name"
-            >
-              
-                    
-              <a
-                class="top-download-page"
-                href="http://rude-war.name"
-                rel="noopener"
-                target="_blank"
-              >
-                
-                      synergize wireless synergies
-                    
-              </a>
-              
-                  
-            </span>
-            
-                  
-            <span
-              class="domain"
-            >
-              
-                    rude-war.name
-                  
-            </span>
-            
-                  
-            <span
-              class="divider"
-            >
-              /
-            </span>
-            
-                  
-            <span
-              class="filename"
-            >
-              
-                    
-              <a
-                aria-label="safely_heavenly_rumour.json"
-                class="top-download-file"
-                href="https://rude-war.namesafely_heavenly_rumour.json"
-                rel="noopener"
-                target="_blank"
-              >
-                
-                      download file
-                    
-              </a>
-              
-                  
-            </span>
-          </div>
-          <div
-            class="chart__bar-chart__item__value"
-          >
-            9,186
-          </div>
-          <div
-            class="chart__bar-chart__item__bar bg-light-blue"
-            style="width: 93%;"
-          />
-        </div>
-        <div
-          class="chart__bar-chart__item"
-        >
-          <div
-            class="chart__bar-chart__item__label dark-grey text--overflow-ellipsis margin-right-8"
-          >
-            <span
-              class="name"
-            >
-              
-                    
-              <a
-                class="top-download-page"
-                href="http://productive-crocodile.org"
-                rel="noopener"
-                target="_blank"
-              >
-                
-                      matrix frictionless bandwidth
-                    
-              </a>
-              
-                  
-            </span>
-            
-                  
-            <span
-              class="domain"
-            >
-              
-                    productive-crocodile.org
-                  
-            </span>
-            
-                  
-            <span
-              class="divider"
-            >
-              /
-            </span>
-            
-                  
-            <span
-              class="filename"
-            >
-              
-                    
-              <a
-                aria-label="mmm_ah_aha.list"
-                class="top-download-file"
-                href="https://productive-crocodile.orgmmm_ah_aha.list"
-                rel="noopener"
-                target="_blank"
-              >
-                
-                      download file
-                    
-              </a>
-              
-                  
-            </span>
-          </div>
-          <div
-            class="chart__bar-chart__item__value"
-          >
-            367
+            405
           </div>
           <div
             class="chart__bar-chart__item__bar bg-light-blue"
@@ -2419,18 +1642,17 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has 2
             class="chart__bar-chart__item__label dark-grey text--overflow-ellipsis margin-right-8"
           >
             <span
-              class="name"
+              class="top-download__page-name"
             >
               
                     
               <a
-                class="top-download-page"
-                href="http://clear-cut-disappointment.info"
+                href="http://fitting-scallops.biz"
                 rel="noopener"
                 target="_blank"
               >
                 
-                      brand killer web services
+                      enable customized solutions
                     
               </a>
               
@@ -2439,10 +1661,10 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has 2
             
                   
             <span
-              class="domain"
+              class="top-download__page-domain"
             >
               
-                    clear-cut-disappointment.info
+                    fitting-scallops.biz
                   
             </span>
             
@@ -2455,14 +1677,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has 2
             
                   
             <span
-              class="filename"
+              class="top-download__file-location"
             >
               
                     
               <a
-                aria-label="busy_under_under.arc"
-                class="top-download-file"
-                href="https://clear-cut-disappointment.infobusy_under_under.arc"
+                href="https://knobby-sleuth.name"
                 rel="noopener"
                 target="_blank"
               >
@@ -2477,11 +1697,701 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data has 2
           <div
             class="chart__bar-chart__item__value"
           >
-            5,399
+            8,628
           </div>
           <div
             class="chart__bar-chart__item__bar bg-light-blue"
-            style="width: 55%;"
+            style="width: 89%;"
+          />
+        </div>
+        <div
+          class="chart__bar-chart__item"
+        >
+          <div
+            class="chart__bar-chart__item__label dark-grey text--overflow-ellipsis margin-right-8"
+          >
+            <span
+              class="top-download__page-name"
+            >
+              
+                    
+              <a
+                href="http://heartfelt-crook.biz"
+                rel="noopener"
+                target="_blank"
+              >
+                
+                      monetize extensible initiatives
+                    
+              </a>
+              
+                  
+            </span>
+            
+                  
+            <span
+              class="top-download__page-domain"
+            >
+              
+                    heartfelt-crook.biz
+                  
+            </span>
+            
+                  
+            <span
+              class="divider"
+            >
+              /
+            </span>
+            
+                  
+            <span
+              class="top-download__file-location"
+            >
+              
+                    
+              <a
+                href="https://zigzag-union.org"
+                rel="noopener"
+                target="_blank"
+              >
+                
+                      download file
+                    
+              </a>
+              
+                  
+            </span>
+          </div>
+          <div
+            class="chart__bar-chart__item__value"
+          >
+            1,435
+          </div>
+          <div
+            class="chart__bar-chart__item__bar bg-light-blue"
+            style="width: 16%;"
+          />
+        </div>
+        <div
+          class="chart__bar-chart__item"
+        >
+          <div
+            class="chart__bar-chart__item__label dark-grey text--overflow-ellipsis margin-right-8"
+          >
+            <span
+              class="top-download__page-name"
+            >
+              
+                    
+              <a
+                href="http://exciting-disclaimer.info"
+                rel="noopener"
+                target="_blank"
+              >
+                
+                      implement clicks-and-mortar e-commerce
+                    
+              </a>
+              
+                  
+            </span>
+            
+                  
+            <span
+              class="top-download__page-domain"
+            >
+              
+                    exciting-disclaimer.info
+                  
+            </span>
+            
+                  
+            <span
+              class="divider"
+            >
+              /
+            </span>
+            
+                  
+            <span
+              class="top-download__file-location"
+            >
+              
+                    
+              <a
+                href="https://massive-veteran.biz"
+                rel="noopener"
+                target="_blank"
+              >
+                
+                      download file
+                    
+              </a>
+              
+                  
+            </span>
+          </div>
+          <div
+            class="chart__bar-chart__item__value"
+          >
+            9,727
+          </div>
+          <div
+            class="chart__bar-chart__item__bar bg-light-blue"
+            style="width: 100%;"
+          />
+        </div>
+        <div
+          class="chart__bar-chart__item"
+        >
+          <div
+            class="chart__bar-chart__item__label dark-grey text--overflow-ellipsis margin-right-8"
+          >
+            <span
+              class="top-download__page-name"
+            >
+              
+                    
+              <a
+                href="http://tame-name.name"
+                rel="noopener"
+                target="_blank"
+              >
+                
+                      synergize best-of-breed schemas
+                    
+              </a>
+              
+                  
+            </span>
+            
+                  
+            <span
+              class="top-download__page-domain"
+            >
+              
+                    tame-name.name
+                  
+            </span>
+            
+                  
+            <span
+              class="divider"
+            >
+              /
+            </span>
+            
+                  
+            <span
+              class="top-download__file-location"
+            >
+              
+                    
+              <a
+                href="https://several-strait.info"
+                rel="noopener"
+                target="_blank"
+              >
+                
+                      download file
+                    
+              </a>
+              
+                  
+            </span>
+          </div>
+          <div
+            class="chart__bar-chart__item__value"
+          >
+            1,036
+          </div>
+          <div
+            class="chart__bar-chart__item__bar bg-light-blue"
+            style="width: 12%;"
+          />
+        </div>
+        <div
+          class="chart__bar-chart__item"
+        >
+          <div
+            class="chart__bar-chart__item__label dark-grey text--overflow-ellipsis margin-right-8"
+          >
+            <span
+              class="top-download__page-name"
+            >
+              
+                    
+              <a
+                href="http://giddy-octagon.org"
+                rel="noopener"
+                target="_blank"
+              >
+                
+                      harness one-to-one solutions
+                    
+              </a>
+              
+                  
+            </span>
+            
+                  
+            <span
+              class="top-download__page-domain"
+            >
+              
+                    giddy-octagon.org
+                  
+            </span>
+            
+                  
+            <span
+              class="divider"
+            >
+              /
+            </span>
+            
+                  
+            <span
+              class="top-download__file-location"
+            >
+              
+                    
+              <a
+                href="https://wooden-anteater.biz"
+                rel="noopener"
+                target="_blank"
+              >
+                
+                      download file
+                    
+              </a>
+              
+                  
+            </span>
+          </div>
+          <div
+            class="chart__bar-chart__item__value"
+          >
+            5,762
+          </div>
+          <div
+            class="chart__bar-chart__item__bar bg-light-blue"
+            style="width: 60%;"
+          />
+        </div>
+        <div
+          class="chart__bar-chart__item"
+        >
+          <div
+            class="chart__bar-chart__item__label dark-grey text--overflow-ellipsis margin-right-8"
+          >
+            <span
+              class="top-download__page-name"
+            >
+              
+                    
+              <a
+                href="http://early-dragster.net"
+                rel="noopener"
+                target="_blank"
+              >
+                
+                      morph e-business technologies
+                    
+              </a>
+              
+                  
+            </span>
+            
+                  
+            <span
+              class="top-download__page-domain"
+            >
+              
+                    early-dragster.net
+                  
+            </span>
+            
+                  
+            <span
+              class="divider"
+            >
+              /
+            </span>
+            
+                  
+            <span
+              class="top-download__file-location"
+            >
+              
+                    
+              <a
+                href="https://witty-wasabi.name"
+                rel="noopener"
+                target="_blank"
+              >
+                
+                      download file
+                    
+              </a>
+              
+                  
+            </span>
+          </div>
+          <div
+            class="chart__bar-chart__item__value"
+          >
+            9,656
+          </div>
+          <div
+            class="chart__bar-chart__item__bar bg-light-blue"
+            style="width: 99%;"
+          />
+        </div>
+        <div
+          class="chart__bar-chart__item"
+        >
+          <div
+            class="chart__bar-chart__item__label dark-grey text--overflow-ellipsis margin-right-8"
+          >
+            <span
+              class="top-download__page-name"
+            >
+              
+                    
+              <a
+                href="http://gray-aggression.info"
+                rel="noopener"
+                target="_blank"
+              >
+                
+                      engage web-enabled functionalities
+                    
+              </a>
+              
+                  
+            </span>
+            
+                  
+            <span
+              class="top-download__page-domain"
+            >
+              
+                    gray-aggression.info
+                  
+            </span>
+            
+                  
+            <span
+              class="divider"
+            >
+              /
+            </span>
+            
+                  
+            <span
+              class="top-download__file-location"
+            >
+              
+                    
+              <a
+                href="https://glossy-shootdown.info"
+                rel="noopener"
+                target="_blank"
+              >
+                
+                      download file
+                    
+              </a>
+              
+                  
+            </span>
+          </div>
+          <div
+            class="chart__bar-chart__item__value"
+          >
+            2,127
+          </div>
+          <div
+            class="chart__bar-chart__item__bar bg-light-blue"
+            style="width: 23%;"
+          />
+        </div>
+        <div
+          class="chart__bar-chart__item"
+        >
+          <div
+            class="chart__bar-chart__item__label dark-grey text--overflow-ellipsis margin-right-8"
+          >
+            <span
+              class="top-download__page-name"
+            >
+              
+                    
+              <a
+                href="http://heartfelt-elite.net"
+                rel="noopener"
+                target="_blank"
+              >
+                
+                      seize viral solutions
+                    
+              </a>
+              
+                  
+            </span>
+            
+                  
+            <span
+              class="top-download__page-domain"
+            >
+              
+                    heartfelt-elite.net
+                  
+            </span>
+            
+                  
+            <span
+              class="divider"
+            >
+              /
+            </span>
+            
+                  
+            <span
+              class="top-download__file-location"
+            >
+              
+                    
+              <a
+                href="https://perky-bandwidth.com"
+                rel="noopener"
+                target="_blank"
+              >
+                
+                      download file
+                    
+              </a>
+              
+                  
+            </span>
+          </div>
+          <div
+            class="chart__bar-chart__item__value"
+          >
+            6,133
+          </div>
+          <div
+            class="chart__bar-chart__item__bar bg-light-blue"
+            style="width: 63%;"
+          />
+        </div>
+        <div
+          class="chart__bar-chart__item"
+        >
+          <div
+            class="chart__bar-chart__item__label dark-grey text--overflow-ellipsis margin-right-8"
+          >
+            <span
+              class="top-download__page-name"
+            >
+              
+                    
+              <a
+                href="http://overjoyed-sage.org"
+                rel="noopener"
+                target="_blank"
+              >
+                
+                      synergize wireless synergies
+                    
+              </a>
+              
+                  
+            </span>
+            
+                  
+            <span
+              class="top-download__page-domain"
+            >
+              
+                    overjoyed-sage.org
+                  
+            </span>
+            
+                  
+            <span
+              class="divider"
+            >
+              /
+            </span>
+            
+                  
+            <span
+              class="top-download__file-location"
+            >
+              
+                    
+              <a
+                href="https://wary-bachelor.com"
+                rel="noopener"
+                target="_blank"
+              >
+                
+                      download file
+                    
+              </a>
+              
+                  
+            </span>
+          </div>
+          <div
+            class="chart__bar-chart__item__value"
+          >
+            3,228
+          </div>
+          <div
+            class="chart__bar-chart__item__bar bg-light-blue"
+            style="width: 34%;"
+          />
+        </div>
+        <div
+          class="chart__bar-chart__item"
+        >
+          <div
+            class="chart__bar-chart__item__label dark-grey text--overflow-ellipsis margin-right-8"
+          >
+            <span
+              class="top-download__page-name"
+            >
+              
+                    
+              <a
+                href="http://critical-lobby.com"
+                rel="noopener"
+                target="_blank"
+              >
+                
+                      matrix frictionless bandwidth
+                    
+              </a>
+              
+                  
+            </span>
+            
+                  
+            <span
+              class="top-download__page-domain"
+            >
+              
+                    critical-lobby.com
+                  
+            </span>
+            
+                  
+            <span
+              class="divider"
+            >
+              /
+            </span>
+            
+                  
+            <span
+              class="top-download__file-location"
+            >
+              
+                    
+              <a
+                href="https://ragged-wildlife.net"
+                rel="noopener"
+                target="_blank"
+              >
+                
+                      download file
+                    
+              </a>
+              
+                  
+            </span>
+          </div>
+          <div
+            class="chart__bar-chart__item__value"
+          >
+            5,610
+          </div>
+          <div
+            class="chart__bar-chart__item__bar bg-light-blue"
+            style="width: 58%;"
+          />
+        </div>
+        <div
+          class="chart__bar-chart__item"
+        >
+          <div
+            class="chart__bar-chart__item__label dark-grey text--overflow-ellipsis margin-right-8"
+          >
+            <span
+              class="top-download__page-name"
+            >
+              
+                    
+              <a
+                href="http://jumbo-fahrenheit.info"
+                rel="noopener"
+                target="_blank"
+              >
+                
+                      brand killer web services
+                    
+              </a>
+              
+                  
+            </span>
+            
+                  
+            <span
+              class="top-download__page-domain"
+            >
+              
+                    jumbo-fahrenheit.info
+                  
+            </span>
+            
+                  
+            <span
+              class="divider"
+            >
+              /
+            </span>
+            
+                  
+            <span
+              class="top-download__file-location"
+            >
+              
+                    
+              <a
+                href="https://separate-cricket.org"
+                rel="noopener"
+                target="_blank"
+              >
+                
+                      download file
+                    
+              </a>
+              
+                  
+            </span>
+          </div>
+          <div
+            class="chart__bar-chart__item__value"
+          >
+            5,672
+          </div>
+          <div
+            class="chart__bar-chart__item__bar bg-light-blue"
+            style="width: 59%;"
           />
         </div>
       </div>
@@ -2541,13 +2451,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
             class="chart__bar-chart__item__label dark-grey text--overflow-ellipsis margin-right-8"
           >
             <span
-              class="name"
+              class="top-download__page-name"
             >
               
                     
               <a
-                class="top-download-page"
-                href="http://jagged-oatmeal.biz"
+                href="http://robust-childhood.com"
                 rel="noopener"
                 target="_blank"
               >
@@ -2561,10 +2470,10 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
             
                   
             <span
-              class="domain"
+              class="top-download__page-domain"
             >
               
-                    jagged-oatmeal.biz
+                    robust-childhood.com
                   
             </span>
             
@@ -2577,14 +2486,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
             
                   
             <span
-              class="filename"
+              class="top-download__file-location"
             >
               
                     
               <a
-                aria-label="inwardly.avif"
-                class="top-download-file"
-                href="https://jagged-oatmeal.bizinwardly.avif"
+                href="https://dizzy-ladybug.net"
                 rel="noopener"
                 target="_blank"
               >
@@ -2599,11 +2506,11 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
           <div
             class="chart__bar-chart__item__value"
           >
-            8,997
+            3,048
           </div>
           <div
             class="chart__bar-chart__item__bar bg-light-blue"
-            style="width: 98%;"
+            style="width: 32%;"
           />
         </div>
         <div
@@ -2613,13 +2520,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
             class="chart__bar-chart__item__label dark-grey text--overflow-ellipsis margin-right-8"
           >
             <span
-              class="name"
+              class="top-download__page-name"
             >
               
                     
               <a
-                class="top-download-page"
-                href="http://swift-chess.org"
+                href="http://early-locality.org"
                 rel="noopener"
                 target="_blank"
               >
@@ -2633,10 +2539,10 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
             
                   
             <span
-              class="domain"
+              class="top-download__page-domain"
             >
               
-                    swift-chess.org
+                    early-locality.org
                   
             </span>
             
@@ -2649,14 +2555,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
             
                   
             <span
-              class="filename"
+              class="top-download__file-location"
             >
               
                     
               <a
-                aria-label="partial_as_feminize.pkg"
-                class="top-download-file"
-                href="https://swift-chess.orgpartial_as_feminize.pkg"
+                href="https://questionable-lake.net"
                 rel="noopener"
                 target="_blank"
               >
@@ -2671,11 +2575,11 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
           <div
             class="chart__bar-chart__item__value"
           >
-            9,071
+            6,120
           </div>
           <div
             class="chart__bar-chart__item__bar bg-light-blue"
-            style="width: 98%;"
+            style="width: 63%;"
           />
         </div>
         <div
@@ -2685,13 +2589,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
             class="chart__bar-chart__item__label dark-grey text--overflow-ellipsis margin-right-8"
           >
             <span
-              class="name"
+              class="top-download__page-name"
             >
               
                     
               <a
-                class="top-download-page"
-                href="http://costly-journalist.net"
+                href="http://wide-intervention.name"
                 rel="noopener"
                 target="_blank"
               >
@@ -2705,10 +2608,10 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
             
                   
             <span
-              class="domain"
+              class="top-download__page-domain"
             >
               
-                    costly-journalist.net
+                    wide-intervention.name
                   
             </span>
             
@@ -2721,14 +2624,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
             
                   
             <span
-              class="filename"
+              class="top-download__file-location"
             >
               
                     
               <a
-                aria-label="inasmuch_drain.ogv"
-                class="top-download-file"
-                href="https://costly-journalist.netinasmuch_drain.ogv"
+                href="https://kindhearted-opening.biz"
                 rel="noopener"
                 target="_blank"
               >
@@ -2743,11 +2644,11 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
           <div
             class="chart__bar-chart__item__value"
           >
-            8,505
+            4,440
           </div>
           <div
             class="chart__bar-chart__item__bar bg-light-blue"
-            style="width: 92%;"
+            style="width: 46%;"
           />
         </div>
         <div
@@ -2757,13 +2658,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
             class="chart__bar-chart__item__label dark-grey text--overflow-ellipsis margin-right-8"
           >
             <span
-              class="name"
+              class="top-download__page-name"
             >
               
                     
               <a
-                class="top-download-page"
-                href="http://striped-twilight.name"
+                href="http://vain-coil.name"
                 rel="noopener"
                 target="_blank"
               >
@@ -2777,10 +2677,10 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
             
                   
             <span
-              class="domain"
+              class="top-download__page-domain"
             >
               
-                    striped-twilight.name
+                    vain-coil.name
                   
             </span>
             
@@ -2793,14 +2693,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
             
                   
             <span
-              class="filename"
+              class="top-download__file-location"
             >
               
                     
               <a
-                aria-label="so.mp4"
-                class="top-download-file"
-                href="https://striped-twilight.nameso.mp4"
+                href="https://crisp-barber.com"
                 rel="noopener"
                 target="_blank"
               >
@@ -2815,11 +2713,11 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
           <div
             class="chart__bar-chart__item__value"
           >
-            7,699
+            494
           </div>
           <div
             class="chart__bar-chart__item__bar bg-light-blue"
-            style="width: 84%;"
+            style="width: 6%;"
           />
         </div>
         <div
@@ -2829,13 +2727,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
             class="chart__bar-chart__item__label dark-grey text--overflow-ellipsis margin-right-8"
           >
             <span
-              class="name"
+              class="top-download__page-name"
             >
               
                     
               <a
-                class="top-download-page"
-                href="http://medical-conductor.net"
+                href="http://shameful-contest.org"
                 rel="noopener"
                 target="_blank"
               >
@@ -2849,10 +2746,10 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
             
                   
             <span
-              class="domain"
+              class="top-download__page-domain"
             >
               
-                    medical-conductor.net
+                    shameful-contest.org
                   
             </span>
             
@@ -2865,14 +2762,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
             
                   
             <span
-              class="filename"
+              class="top-download__file-location"
             >
               
                     
               <a
-                aria-label="jelly_woot.svg"
-                class="top-download-file"
-                href="https://medical-conductor.netjelly_woot.svg"
+                href="https://open-territory.name"
                 rel="noopener"
                 target="_blank"
               >
@@ -2887,11 +2782,11 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
           <div
             class="chart__bar-chart__item__value"
           >
-            1,142
+            6,711
           </div>
           <div
             class="chart__bar-chart__item__bar bg-light-blue"
-            style="width: 13%;"
+            style="width: 70%;"
           />
         </div>
         <div
@@ -2901,13 +2796,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
             class="chart__bar-chart__item__label dark-grey text--overflow-ellipsis margin-right-8"
           >
             <span
-              class="name"
+              class="top-download__page-name"
             >
               
                     
               <a
-                class="top-download-page"
-                href="http://fatal-subscription.name"
+                href="http://unwelcome-pressroom.com"
                 rel="noopener"
                 target="_blank"
               >
@@ -2921,10 +2815,10 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
             
                   
             <span
-              class="domain"
+              class="top-download__page-domain"
             >
               
-                    fatal-subscription.name
+                    unwelcome-pressroom.com
                   
             </span>
             
@@ -2937,14 +2831,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
             
                   
             <span
-              class="filename"
+              class="top-download__file-location"
             >
               
                     
               <a
-                aria-label="inquisitively.ods"
-                class="top-download-file"
-                href="https://fatal-subscription.nameinquisitively.ods"
+                href="https://athletic-cellar.com"
                 rel="noopener"
                 target="_blank"
               >
@@ -2959,11 +2851,11 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
           <div
             class="chart__bar-chart__item__value"
           >
-            5,030
+            4,531
           </div>
           <div
             class="chart__bar-chart__item__bar bg-light-blue"
-            style="width: 55%;"
+            style="width: 47%;"
           />
         </div>
         <div
@@ -2973,13 +2865,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
             class="chart__bar-chart__item__label dark-grey text--overflow-ellipsis margin-right-8"
           >
             <span
-              class="name"
+              class="top-download__page-name"
             >
               
                     
               <a
-                class="top-download-page"
-                href="http://pleasing-ramie.biz"
+                href="http://eager-breakdown.net"
                 rel="noopener"
                 target="_blank"
               >
@@ -2993,10 +2884,10 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
             
                   
             <span
-              class="domain"
+              class="top-download__page-domain"
             >
               
-                    pleasing-ramie.biz
+                    eager-breakdown.net
                   
             </span>
             
@@ -3009,14 +2900,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
             
                   
             <span
-              class="filename"
+              class="top-download__file-location"
             >
               
                     
               <a
-                aria-label="applaud.img"
-                class="top-download-file"
-                href="https://pleasing-ramie.bizapplaud.img"
+                href="https://difficult-resist.net"
                 rel="noopener"
                 target="_blank"
               >
@@ -3031,11 +2920,11 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
           <div
             class="chart__bar-chart__item__value"
           >
-            6,966
+            691
           </div>
           <div
             class="chart__bar-chart__item__bar bg-light-blue"
-            style="width: 76%;"
+            style="width: 8%;"
           />
         </div>
         <div
@@ -3045,13 +2934,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
             class="chart__bar-chart__item__label dark-grey text--overflow-ellipsis margin-right-8"
           >
             <span
-              class="name"
+              class="top-download__page-name"
             >
               
                     
               <a
-                class="top-download-page"
-                href="http://ornery-thaw.org"
+                href="http://honest-reliability.name"
                 rel="noopener"
                 target="_blank"
               >
@@ -3065,10 +2953,10 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
             
                   
             <span
-              class="domain"
+              class="top-download__page-domain"
             >
               
-                    ornery-thaw.org
+                    honest-reliability.name
                   
             </span>
             
@@ -3081,14 +2969,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
             
                   
             <span
-              class="filename"
+              class="top-download__file-location"
             >
               
                     
               <a
-                aria-label="blah_wherever.dms"
-                class="top-download-file"
-                href="https://ornery-thaw.orgblah_wherever.dms"
+                href="https://haunting-shoes.biz"
                 rel="noopener"
                 target="_blank"
               >
@@ -3103,11 +2989,11 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
           <div
             class="chart__bar-chart__item__value"
           >
-            5,602
+            3,970
           </div>
           <div
             class="chart__bar-chart__item__bar bg-light-blue"
-            style="width: 61%;"
+            style="width: 42%;"
           />
         </div>
         <div
@@ -3117,13 +3003,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
             class="chart__bar-chart__item__label dark-grey text--overflow-ellipsis margin-right-8"
           >
             <span
-              class="name"
+              class="top-download__page-name"
             >
               
                     
               <a
-                class="top-download-page"
-                href="http://watchful-maelstrom.org"
+                href="http://hidden-yarn.org"
                 rel="noopener"
                 target="_blank"
               >
@@ -3137,10 +3022,10 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
             
                   
             <span
-              class="domain"
+              class="top-download__page-domain"
             >
               
-                    watchful-maelstrom.org
+                    hidden-yarn.org
                   
             </span>
             
@@ -3153,14 +3038,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
             
                   
             <span
-              class="filename"
+              class="top-download__file-location"
             >
               
                     
               <a
-                aria-label="safe_dear.distz"
-                class="top-download-file"
-                href="https://watchful-maelstrom.orgsafe_dear.distz"
+                href="https://jumbo-counselor.net"
                 rel="noopener"
                 target="_blank"
               >
@@ -3175,7 +3058,7 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
           <div
             class="chart__bar-chart__item__value"
           >
-            9,217
+            9,697
           </div>
           <div
             class="chart__bar-chart__item__bar bg-light-blue"
@@ -3189,13 +3072,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
             class="chart__bar-chart__item__label dark-grey text--overflow-ellipsis margin-right-8"
           >
             <span
-              class="name"
+              class="top-download__page-name"
             >
               
                     
               <a
-                class="top-download-page"
-                href="http://puny-protocol.org"
+                href="http://outgoing-journalism.name"
                 rel="noopener"
                 target="_blank"
               >
@@ -3209,10 +3091,10 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
             
                   
             <span
-              class="domain"
+              class="top-download__page-domain"
             >
               
-                    puny-protocol.org
+                    outgoing-journalism.name
                   
             </span>
             
@@ -3225,14 +3107,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
             
                   
             <span
-              class="filename"
+              class="top-download__file-location"
             >
               
                     
               <a
-                aria-label="around_psst.mid"
-                class="top-download-file"
-                href="https://puny-protocol.orgaround_psst.mid"
+                href="https://lanky-gratitude.net"
                 rel="noopener"
                 target="_blank"
               >
@@ -3247,11 +3127,11 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
           <div
             class="chart__bar-chart__item__value"
           >
-            4,865
+            3,534
           </div>
           <div
             class="chart__bar-chart__item__bar bg-light-blue"
-            style="width: 53%;"
+            style="width: 37%;"
           />
         </div>
         <div
@@ -3261,13 +3141,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
             class="chart__bar-chart__item__label dark-grey text--overflow-ellipsis margin-right-8"
           >
             <span
-              class="name"
+              class="top-download__page-name"
             >
               
                     
               <a
-                class="top-download-page"
-                href="http://potable-cot.org"
+                href="http://giant-daddy.name"
                 rel="noopener"
                 target="_blank"
               >
@@ -3281,10 +3160,10 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
             
                   
             <span
-              class="domain"
+              class="top-download__page-domain"
             >
               
-                    potable-cot.org
+                    giant-daddy.name
                   
             </span>
             
@@ -3297,14 +3176,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
             
                   
             <span
-              class="filename"
+              class="top-download__file-location"
             >
               
                     
               <a
-                aria-label="per_furiously.odp"
-                class="top-download-file"
-                href="https://potable-cot.orgper_furiously.odp"
+                href="https://quaint-boycott.name"
                 rel="noopener"
                 target="_blank"
               >
@@ -3319,11 +3196,11 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
           <div
             class="chart__bar-chart__item__value"
           >
-            2,121
+            6,774
           </div>
           <div
             class="chart__bar-chart__item__bar bg-light-blue"
-            style="width: 24%;"
+            style="width: 70%;"
           />
         </div>
         <div
@@ -3333,13 +3210,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
             class="chart__bar-chart__item__label dark-grey text--overflow-ellipsis margin-right-8"
           >
             <span
-              class="name"
+              class="top-download__page-name"
             >
               
                     
               <a
-                class="top-download-page"
-                href="http://creepy-yin.biz"
+                href="http://smoggy-obligation.name"
                 rel="noopener"
                 target="_blank"
               >
@@ -3353,10 +3229,10 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
             
                   
             <span
-              class="domain"
+              class="top-download__page-domain"
             >
               
-                    creepy-yin.biz
+                    smoggy-obligation.name
                   
             </span>
             
@@ -3369,14 +3245,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
             
                   
             <span
-              class="filename"
+              class="top-download__file-location"
             >
               
                     
               <a
-                aria-label="among_frightfully.m2a"
-                class="top-download-file"
-                href="https://creepy-yin.bizamong_frightfully.m2a"
+                href="https://medical-detail.com"
                 rel="noopener"
                 target="_blank"
               >
@@ -3391,11 +3265,11 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
           <div
             class="chart__bar-chart__item__value"
           >
-            1,804
+            5,288
           </div>
           <div
             class="chart__bar-chart__item__bar bg-light-blue"
-            style="width: 20%;"
+            style="width: 55%;"
           />
         </div>
         <div
@@ -3405,13 +3279,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
             class="chart__bar-chart__item__label dark-grey text--overflow-ellipsis margin-right-8"
           >
             <span
-              class="name"
+              class="top-download__page-name"
             >
               
                     
               <a
-                class="top-download-page"
-                href="http://untried-morphology.net"
+                href="http://ragged-millet.org"
                 rel="noopener"
                 target="_blank"
               >
@@ -3425,10 +3298,10 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
             
                   
             <span
-              class="domain"
+              class="top-download__page-domain"
             >
               
-                    untried-morphology.net
+                    ragged-millet.org
                   
             </span>
             
@@ -3441,14 +3314,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
             
                   
             <span
-              class="filename"
+              class="top-download__file-location"
             >
               
                     
               <a
-                aria-label="home_seemingly.map"
-                class="top-download-file"
-                href="https://untried-morphology.nethome_seemingly.map"
+                href="https://oily-cloister.name"
                 rel="noopener"
                 target="_blank"
               >
@@ -3463,11 +3334,11 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
           <div
             class="chart__bar-chart__item__value"
           >
-            7,889
+            559
           </div>
           <div
             class="chart__bar-chart__item__bar bg-light-blue"
-            style="width: 86%;"
+            style="width: 7%;"
           />
         </div>
         <div
@@ -3477,13 +3348,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
             class="chart__bar-chart__item__label dark-grey text--overflow-ellipsis margin-right-8"
           >
             <span
-              class="name"
+              class="top-download__page-name"
             >
               
                     
               <a
-                class="top-download-page"
-                href="http://outstanding-apparatus.info"
+                href="http://indelible-amount.biz"
                 rel="noopener"
                 target="_blank"
               >
@@ -3497,10 +3367,10 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
             
                   
             <span
-              class="domain"
+              class="top-download__page-domain"
             >
               
-                    outstanding-apparatus.info
+                    indelible-amount.biz
                   
             </span>
             
@@ -3513,14 +3383,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
             
                   
             <span
-              class="filename"
+              class="top-download__file-location"
             >
               
                     
               <a
-                aria-label="macerate_zealous.rtf"
-                class="top-download-file"
-                href="https://outstanding-apparatus.infomacerate_zealous.rtf"
+                href="https://long-oeuvre.name"
                 rel="noopener"
                 target="_blank"
               >
@@ -3535,11 +3403,11 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
           <div
             class="chart__bar-chart__item__value"
           >
-            3,102
+            8,144
           </div>
           <div
             class="chart__bar-chart__item__bar bg-light-blue"
-            style="width: 34%;"
+            style="width: 84%;"
           />
         </div>
         <div
@@ -3549,13 +3417,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
             class="chart__bar-chart__item__label dark-grey text--overflow-ellipsis margin-right-8"
           >
             <span
-              class="name"
+              class="top-download__page-name"
             >
               
                     
               <a
-                class="top-download-page"
-                href="http://pointed-seller.org"
+                href="http://lumbering-living.biz"
                 rel="noopener"
                 target="_blank"
               >
@@ -3569,10 +3436,10 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
             
                   
             <span
-              class="domain"
+              class="top-download__page-domain"
             >
               
-                    pointed-seller.org
+                    lumbering-living.biz
                   
             </span>
             
@@ -3585,14 +3452,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
             
                   
             <span
-              class="filename"
+              class="top-download__file-location"
             >
               
                     
               <a
-                aria-label="slate.zip"
-                class="top-download-file"
-                href="https://pointed-seller.orgslate.zip"
+                href="https://costly-media.biz"
                 rel="noopener"
                 target="_blank"
               >
@@ -3607,11 +3472,11 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
           <div
             class="chart__bar-chart__item__value"
           >
-            1,796
+            5,439
           </div>
           <div
             class="chart__bar-chart__item__bar bg-light-blue"
-            style="width: 20%;"
+            style="width: 57%;"
           />
         </div>
         <div
@@ -3621,13 +3486,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
             class="chart__bar-chart__item__label dark-grey text--overflow-ellipsis margin-right-8"
           >
             <span
-              class="name"
+              class="top-download__page-name"
             >
               
                     
               <a
-                class="top-download-page"
-                href="http://respectful-upward.info"
+                href="http://suspicious-antler.net"
                 rel="noopener"
                 target="_blank"
               >
@@ -3641,10 +3505,10 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
             
                   
             <span
-              class="domain"
+              class="top-download__page-domain"
             >
               
-                    respectful-upward.info
+                    suspicious-antler.net
                   
             </span>
             
@@ -3657,14 +3521,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
             
                   
             <span
-              class="filename"
+              class="top-download__file-location"
             >
               
                     
               <a
-                aria-label="gah_brutalize_definite.7z"
-                class="top-download-file"
-                href="https://respectful-upward.infogah_brutalize_definite.7z"
+                href="https://unwilling-fencing.com"
                 rel="noopener"
                 target="_blank"
               >
@@ -3679,11 +3541,11 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
           <div
             class="chart__bar-chart__item__value"
           >
-            108
+            7,968
           </div>
           <div
             class="chart__bar-chart__item__bar bg-light-blue"
-            style="width: 2%;"
+            style="width: 82%;"
           />
         </div>
         <div
@@ -3693,13 +3555,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
             class="chart__bar-chart__item__label dark-grey text--overflow-ellipsis margin-right-8"
           >
             <span
-              class="name"
+              class="top-download__page-name"
             >
               
                     
               <a
-                class="top-download-page"
-                href="http://nice-nonsense.biz"
+                href="http://lavish-cenotaph.org"
                 rel="noopener"
                 target="_blank"
               >
@@ -3713,10 +3574,10 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
             
                   
             <span
-              class="domain"
+              class="top-download__page-domain"
             >
               
-                    nice-nonsense.biz
+                    lavish-cenotaph.org
                   
             </span>
             
@@ -3729,14 +3590,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
             
                   
             <span
-              class="filename"
+              class="top-download__file-location"
             >
               
                     
               <a
-                aria-label="adventurously_note_incision.mp3"
-                class="top-download-file"
-                href="https://nice-nonsense.bizadventurously_note_incision.mp3"
+                href="https://villainous-heaven.info"
                 rel="noopener"
                 target="_blank"
               >
@@ -3751,11 +3610,11 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
           <div
             class="chart__bar-chart__item__value"
           >
-            2,046
+            2,433
           </div>
           <div
             class="chart__bar-chart__item__bar bg-light-blue"
-            style="width: 23%;"
+            style="width: 26%;"
           />
         </div>
         <div
@@ -3765,13 +3624,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
             class="chart__bar-chart__item__label dark-grey text--overflow-ellipsis margin-right-8"
           >
             <span
-              class="name"
+              class="top-download__page-name"
             >
               
                     
               <a
-                class="top-download-page"
-                href="http://voluminous-kale.name"
+                href="http://cool-autumn.info"
                 rel="noopener"
                 target="_blank"
               >
@@ -3785,10 +3643,10 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
             
                   
             <span
-              class="domain"
+              class="top-download__page-domain"
             >
               
-                    voluminous-kale.name
+                    cool-autumn.info
                   
             </span>
             
@@ -3801,14 +3659,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
             
                   
             <span
-              class="filename"
+              class="top-download__file-location"
             >
               
                     
               <a
-                aria-label="time_hiss_solidly.ogg"
-                class="top-download-file"
-                href="https://voluminous-kale.nametime_hiss_solidly.ogg"
+                href="https://serious-legitimacy.org"
                 rel="noopener"
                 target="_blank"
               >
@@ -3823,11 +3679,11 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
           <div
             class="chart__bar-chart__item__value"
           >
-            927
+            7,274
           </div>
           <div
             class="chart__bar-chart__item__bar bg-light-blue"
-            style="width: 11%;"
+            style="width: 75%;"
           />
         </div>
         <div
@@ -3837,13 +3693,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
             class="chart__bar-chart__item__label dark-grey text--overflow-ellipsis margin-right-8"
           >
             <span
-              class="name"
+              class="top-download__page-name"
             >
               
                     
               <a
-                class="top-download-page"
-                href="http://black-and-white-plant.com"
+                href="http://dramatic-quartz.org"
                 rel="noopener"
                 target="_blank"
               >
@@ -3857,10 +3712,10 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
             
                   
             <span
-              class="domain"
+              class="top-download__page-domain"
             >
               
-                    black-and-white-plant.com
+                    dramatic-quartz.org
                   
             </span>
             
@@ -3873,14 +3728,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
             
                   
             <span
-              class="filename"
+              class="top-download__file-location"
             >
               
                     
               <a
-                aria-label="brown_prostanoid.css"
-                class="top-download-file"
-                href="https://black-and-white-plant.combrown_prostanoid.css"
+                href="https://noteworthy-dining.net"
                 rel="noopener"
                 target="_blank"
               >
@@ -3895,11 +3748,11 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
           <div
             class="chart__bar-chart__item__value"
           >
-            1,426
+            6,773
           </div>
           <div
             class="chart__bar-chart__item__bar bg-light-blue"
-            style="width: 16%;"
+            style="width: 70%;"
           />
         </div>
         <div
@@ -3909,13 +3762,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
             class="chart__bar-chart__item__label dark-grey text--overflow-ellipsis margin-right-8"
           >
             <span
-              class="name"
+              class="top-download__page-name"
             >
               
                     
               <a
-                class="top-download-page"
-                href="http://biodegradable-consent.org"
+                href="http://graceful-cabinet.name"
                 rel="noopener"
                 target="_blank"
               >
@@ -3929,10 +3781,10 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
             
                   
             <span
-              class="domain"
+              class="top-download__page-domain"
             >
               
-                    biodegradable-consent.org
+                    graceful-cabinet.name
                   
             </span>
             
@@ -3945,14 +3797,12 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
             
                   
             <span
-              class="filename"
+              class="top-download__file-location"
             >
               
                     
               <a
-                aria-label="um_punt_ugh.vsw"
-                class="top-download-file"
-                href="https://biodegradable-consent.orgum_punt_ugh.vsw"
+                href="https://treasured-tangerine.biz"
                 rel="noopener"
                 target="_blank"
               >
@@ -3967,11 +3817,11 @@ exports[`TopDownloadsAndVideoPlays when data is loaded and video play data is em
           <div
             class="chart__bar-chart__item__value"
           >
-            3,912
+            8,634
           </div>
           <div
             class="chart__bar-chart__item__bar bg-light-blue"
-            style="width: 43%;"
+            style="width: 89%;"
           />
         </div>
       </div>

--- a/js/lib/chart_helpers/__tests__/formatters.spec.js
+++ b/js/lib/chart_helpers/__tests__/formatters.spec.js
@@ -112,11 +112,24 @@ describe("Formatters", () => {
   });
 
   describe("formatFile", () => {
-    it("returns the file name from a given url", () => {
-      assert.equal(
-        formatters.formatFile("https://www.irs.gov:8443/ds82.pdf"),
-        "/ds82.pdf",
-      );
+    describe("when the URL string contains spaces", () => {
+      it("returns the file name from a given url", () => {
+        assert.equal(
+          formatters.formatFile(
+            "https://travel.state.gov/dv 2026 plain language instructions and faqs.pdf",
+          ),
+          "/dv%202026%20plain%20language%20instructions%20and%20faqs.pdf",
+        );
+      });
+    });
+
+    describe("when the URL string does not contain spaces", () => {
+      it("returns the file name from a given url", () => {
+        assert.equal(
+          formatters.formatFile("https://www.irs.gov:8443/ds82.pdf"),
+          "/ds82.pdf",
+        );
+      });
     });
 
     it("returns the same for a clean url", () => {

--- a/sass/pages/root/_secondary-data.scss
+++ b/sass/pages/root/_secondary-data.scss
@@ -118,19 +118,19 @@
         height: 4rem;
         line-height: 1.6;
 
-        .name {
+        .top-download__page-name {
           display: block;
           overflow: hidden;
           text-overflow: ellipsis;
           white-space: nowrap;
         }
 
-        .domain {
+        .top-download__page-domain {
           color: colors.$dark-gray;
           text-transform: lowercase;
         }
 
-        .filename {
+        .top-download__file-location {
           text-transform: lowercase;
         }
       }

--- a/spec/factories/reports/download.js
+++ b/spec/factories/reports/download.js
@@ -7,8 +7,7 @@ const downloadReportDataItemFactory = Factory.define(({ sequence }) => {
   faker.seed(global.faker_seed + sequence);
   const item = {
     page_title: faker.company.buzzPhrase(),
-    event_label: "file_download",
-    file_name: faker.system.fileName(),
+    linkUrl: faker.internet.url({ appendSlash: false }),
     page: faker.internet.url({ appendSlash: false }).replace("https://", ""),
     total_events: faker.number.int({ max: 10000 }),
   };
@@ -23,13 +22,10 @@ const DownloadReportFactory = ReportFactory.params({
         name: "pageTitle",
       },
       {
-        name: "eventName",
-      },
-      {
-        name: "fileName",
-      },
-      {
         name: "fullPageUrl",
+      },
+      {
+        name: "linkUrl",
       },
     ],
     metrics: [


### PR DESCRIPTION
The site has a bug when files which appear in the Top Downloads section have spaces in the filenames.  The HREF for the link to the file will be incorrect.

This PR ensures that the HREF goes to the correct URL with spaces encoded.
