### PR TITLE
Add 'npm audit signatures' to CI workflow.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,10 +41,25 @@ jobs:
         run: npm ci --verbose --timing
       - name: Lint SCSS
         run: npm run lint:styles
+  audit-npm-dependencies:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Code checkout
+        uses: actions/checkout@v4
+      - name: Install node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "lts/*"
+          cache: 'npm'
+      - name: Install node dependencies
+        run: npm ci
+      - name: Validate npm package signatures
+        run: npm audit signatures
   test:
     needs:
       - lint-js
       - lint-styles
+      - audit-npm-dependencies
     runs-on: ubuntu-latest
     steps:
       - name: Code Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v4
         with:
-          node-version: "lts/*"
+          node-version-file: ".nvmrc"
           cache: 'npm'
       - name: Install node dependencies
         # Fix for installing puppeteer which is a pa11y dependency.
@@ -31,7 +31,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v4
         with:
-          node-version: "lts/*"
+          node-version-file: ".nvmrc"
           cache: 'npm'
       - name: Install node dependencies
         # Fix for installing puppeteer which is a pa11y dependency.
@@ -41,15 +41,15 @@ jobs:
         run: npm ci --verbose --timing
       - name: Lint SCSS
         run: npm run lint:styles
-  audit-npm-dependencies:
+  audit-dependencies:
     runs-on: ubuntu-latest
     steps:
       - name: Code checkout
         uses: actions/checkout@v4
-      - name: Install node
+      - name: Install Node
         uses: actions/setup-node@v4
         with:
-          node-version: "lts/*"
+          node-version-file: ".nvmrc"
           cache: 'npm'
       - name: Install node dependencies
         run: npm ci
@@ -59,7 +59,7 @@ jobs:
     needs:
       - lint-js
       - lint-styles
-      - audit-npm-dependencies
+      - audit-dependencies
     runs-on: ubuntu-latest
     steps:
       - name: Code Checkout
@@ -67,7 +67,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v4
         with:
-          node-version: "lts/*"
+          node-version-file: ".nvmrc"
           cache: 'npm'
       - name: Install node dependencies
         # Fix for installing puppeteer which is a pa11y dependency.
@@ -81,6 +81,7 @@ jobs:
     needs:
       - lint-js
       - lint-styles
+      - audit-dependencies
       - test
     if: github.ref == 'refs/heads/develop'
     uses: 18F/analytics.usa.gov/.github/workflows/deploy.yml@develop
@@ -104,6 +105,7 @@ jobs:
     needs:
       - lint-js
       - lint-styles
+      - audit-dependencies
       - test
     if: github.ref == 'refs/heads/staging'
     uses: 18F/analytics.usa.gov/.github/workflows/deploy.yml@develop
@@ -127,6 +129,7 @@ jobs:
     needs:
       - lint-js
       - lint-styles
+      - audit-dependencies
       - test
     if: github.ref == 'refs/heads/master'
     uses: 18F/analytics.usa.gov/.github/workflows/deploy.yml@develop

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v4
         with:
-          node-version: "lts/*"
+          node-version-file: ".nvmrc"
           cache: 'npm'
       - name: Install node dependencies
         run: npm ci --timing


### PR DESCRIPTION
This PR is related to the Trello card [Implement subresource integrity for all analytics.usa.gov application components](https://trello.com/c/jQA2F0JX). npm audit signatures "verifies the registry signatures of downloaded packages" that "you download from the public npm registry, or any registry that supports signatures". It also verifies the ["provenance attestations"](https://slsa.dev/spec/v1.0/provenance) of any packages that provide them.