### PR TITLE
Potential fix for code scanning alert no. 14: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI workflow
 
+permissions:
+  contents: read
+
 on:
   push:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/18F/analytics.usa.gov/security/code-scanning/14](https://github.com/18F/analytics.usa.gov/security/code-scanning/14)

In general, the fix is to explicitly declare `permissions:` for the workflow or for individual jobs so that the automatically generated GITHUB_TOKEN is restricted to the minimal rights needed. For pure CI jobs that only read code and run commands, `contents: read` is sufficient; often you can make the default even tighter (`permissions: read-all` or `permissions: {}`) and then selectively grant additional rights only where necessary (e.g., in deploy jobs or release jobs).

For this workflow, the simplest, least‑disruptive change is:

1. Add a workflow‑level `permissions:` block near the top (after `name:` and before `on:`), setting `contents: read`. This covers all the lint/test/a11y jobs, which only need to check out code.
2. The `deploy_dev`, `deploy_stg`, and `deploy_prd` jobs call a reusable `deploy.yml` workflow that likely needs to interact with GitHub or other resources; however, the minimal safe change that satisfies CodeQL without breaking existing behavior is to inherit the workflow‑level permissions. If in your repo the deploy workflow needs write permissions (e.g., to update deployments, statuses, or contents), you can later override those three jobs individually with their own `permissions:` blocks. Since that file isn’t shown, we won’t assume details here.

Concretely, edit `.github/workflows/ci.yml` to insert:

```yaml
permissions:
  contents: read
```

right after `name: CI workflow` and before the `on:` block. No other imports or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
