### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/manual_deploy_to_dev.yml
+++ b/.github/workflows/manual_deploy_to_dev.yml
@@ -3,6 +3,9 @@ name: Manual deploy to dev
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   manual_deploy_to_dev:
     uses: 18F/analytics.usa.gov/.github/workflows/deploy.yml@develop


### PR DESCRIPTION
Potential fix for [https://github.com/18F/analytics.usa.gov/security/code-scanning/6](https://github.com/18F/analytics.usa.gov/security/code-scanning/6)

In general, to fix this type of issue you must add an explicit `permissions` block either at the root of the workflow (applies to all jobs without their own permissions) or under the specific job. The block should grant the minimum `GITHUB_TOKEN` scopes needed for the job to function (for many workflows this is `contents: read`, with additional scopes as required).

For this specific workflow `.github/workflows/manual_deploy_to_dev.yml`, the simplest non-breaking fix is to add a top-level `permissions` block after the `on:` section and before `jobs:`. Since we do not see any direct use of `GITHUB_TOKEN` in this wrapper workflow and the heavy lifting is delegated to the reusable `deploy.yml`, we should set a minimal, safe default such as `contents: read`. The reusable workflow can still request more specific permissions in its own definition if needed; GitHub will intersect those with this top-level set. This approach does not change any functional behavior within this file other than constraining the token’s implicit privileges and it addresses the CodeQL warning.

Concretely:
- Edit `.github/workflows/manual_deploy_to_dev.yml`.
- Insert:

  ```yaml
  permissions:
    contents: read
  ```

  between the `on:` block and the `jobs:` block (i.e., after line 5 and before line 6 in your snippet).
- No additional imports or definitions are needed; this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
