### PR TITLE
Change the google site verification tag.

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -24,7 +24,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=Edge" />
   <meta
     name="google-site-verification"
-    content="3M4CQMJIt6qoilByli-rZfUFU6ET-No8gF12dAQFPfc"
+    content="MRDQ2c7ndOHtHw40F82TJF6SlXsTFv8hdA4gJKRT8FI"
   />
 
   <link rel="stylesheet" href="{{ site.baseurl }}/css/styles.css" />


### PR DESCRIPTION
## Summary
Members of the current DAP team need to claim ownership of https://analytics.usa.gov/ for the Google Search Console (again).


## This pull request is ready to merge when...
- [ ] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
- [ ] The change has been documented

