### PR TITLE
Add DeepWiki documentation badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/18F/analytics.usa.gov)
 ![Build Status](https://github.com/18F/analytics.usa.gov/actions/workflows/ci.yml/badge.svg?branch=master)
 [![Snyk](https://snyk.io/test/github/18F/analytics.usa.gov/badge.svg)](https://snyk.io/test/github/18F/analytics.usa.gov)
 


### PR DESCRIPTION
Adds a [DeepWiki](https://deepwiki.com/18F/analytics.usa.gov) badge to the README for auto-generated interactive documentation.

This is a minimal, single-line addition.