### PR TITLE
Tighten up CSP for DAP code inclusion.

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -85,7 +85,7 @@ http {
       resolver               8.8.8.8 valid=300s;
 
       add_header             Cache-Control "no-cache";
-      add_header             Content-Security-Policy "default-src 'self'; script-src 'self' https://dap.digitalgov.gov https://www.google-analytics.com https://www.googletagmanager.com https://touchpoints.app.cloud.gov; connect-src 'self' https://www.google-analytics.com https://touchpoints.app.cloud.gov; img-src 'self' https://touchpoints.app.cloud.gov https://cg-1b082c1b-3db7-477f-9ca5-bd51a786b41e.s3-us-gov-west-1.amazonaws.com; form-action https://www.google.com; frame-ancestors 'none';" always;
+      add_header             Content-Security-Policy "default-src 'self'; script-src 'self' https://dap.digitalgov.gov https://www.googletagmanager.com https://touchpoints.app.cloud.gov; connect-src 'self' https://www.google-analytics.com https://touchpoints.app.cloud.gov; img-src 'self' https://touchpoints.app.cloud.gov https://cg-1b082c1b-3db7-477f-9ca5-bd51a786b41e.s3-us-gov-west-1.amazonaws.com; form-action https://www.google.com; frame-ancestors 'none';" always;
       add_header             Permissions-Policy "autoplay=(), encrypted-media=(), fullscreen=(), geolocation=(), microphone=(), midi=(), payment=()" always;
       add_header             Pragma "no-cache";
       add_header             Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
@@ -114,7 +114,7 @@ http {
       # Touchpoints and S3 domains are added to the CSP support touchpoints JS
       # code which dynamically adds HTML with images and references JS on the
       # touchpoints server.
-      add_header Content-Security-Policy "default-src 'self'; script-src 'self' https://dap.digitalgov.gov https://www.google-analytics.com https://www.googletagmanager.com https://touchpoints.app.cloud.gov; connect-src 'self' https://www.google-analytics.com https://touchpoints.app.cloud.gov; img-src 'self' https://touchpoints.app.cloud.gov https://cg-1b082c1b-3db7-477f-9ca5-bd51a786b41e.s3-us-gov-west-1.amazonaws.com; form-action https://www.google.com; frame-ancestors 'none';" always;
+      add_header Content-Security-Policy "default-src 'self'; script-src 'self' https://dap.digitalgov.gov https://www.googletagmanager.com https://touchpoints.app.cloud.gov; connect-src 'self' https://www.google-analytics.com https://touchpoints.app.cloud.gov; img-src 'self' https://touchpoints.app.cloud.gov https://cg-1b082c1b-3db7-477f-9ca5-bd51a786b41e.s3-us-gov-west-1.amazonaws.com; form-action https://www.google.com; frame-ancestors 'none';" always;
       add_header Permissions-Policy "autoplay=(), encrypted-media=(), fullscreen=(), geolocation=(), microphone=(), midi=(), payment=()" always;
       add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
       add_header X-Content-Type-Options "nosniff" always;
@@ -122,7 +122,7 @@ http {
     }
 
     location =/developers {
-      add_header Content-Security-Policy "default-src 'self'; script-src 'self' https://dap.digitalgov.gov https://www.google-analytics.com https://www.googletagmanager.com https://touchpoints.app.cloud.gov; connect-src 'self' https://www.google-analytics.com https://touchpoints.app.cloud.gov; img-src 'self' https://touchpoints.app.cloud.gov https://cg-1b082c1b-3db7-477f-9ca5-bd51a786b41e.s3-us-gov-west-1.amazonaws.com; form-action 'none'; frame-ancestors 'none';" always;
+      add_header Content-Security-Policy "default-src 'self'; script-src 'self' https://dap.digitalgov.gov https://www.googletagmanager.com https://touchpoints.app.cloud.gov; connect-src 'self' https://www.google-analytics.com https://touchpoints.app.cloud.gov; img-src 'self' https://touchpoints.app.cloud.gov https://cg-1b082c1b-3db7-477f-9ca5-bd51a786b41e.s3-us-gov-west-1.amazonaws.com; form-action 'none'; frame-ancestors 'none';" always;
       add_header Permissions-Policy "autoplay=(), encrypted-media=(), fullscreen=(), geolocation=(), microphone=(), midi=(), payment=()" always;
       add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
       add_header X-Content-Type-Options "nosniff" always;
@@ -130,7 +130,7 @@ http {
     }
 
     location =/developer {
-      add_header Content-Security-Policy "default-src 'self'; script-src 'self' https://dap.digitalgov.gov https://www.google-analytics.com https://www.googletagmanager.com https://touchpoints.app.cloud.gov; connect-src 'self' https://www.google-analytics.com https://touchpoints.app.cloud.gov; img-src 'self' https://touchpoints.app.cloud.gov https://cg-1b082c1b-3db7-477f-9ca5-bd51a786b41e.s3-us-gov-west-1.amazonaws.com; form-action 'none'; frame-ancestors 'none';" always;
+      add_header Content-Security-Policy "default-src 'self'; script-src 'self' https://dap.digitalgov.gov https://www.googletagmanager.com https://touchpoints.app.cloud.gov; connect-src 'self' https://www.google-analytics.com https://touchpoints.app.cloud.gov; img-src 'self' https://touchpoints.app.cloud.gov https://cg-1b082c1b-3db7-477f-9ca5-bd51a786b41e.s3-us-gov-west-1.amazonaws.com; form-action 'none'; frame-ancestors 'none';" always;
       add_header Permissions-Policy "autoplay=(), encrypted-media=(), fullscreen=(), geolocation=(), microphone=(), midi=(), payment=()" always;
       add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
       add_header X-Content-Type-Options "nosniff" always;


### PR DESCRIPTION
Our current DAP documentation recommends adding `script-src https://www.google-analytics.com` to the CSP on DAP-enabled pages but I don't think any GA scripts are loaded from that domain. Testing this theory on https://analytics.usa.gov/.