### PR TITLE
Add dap.digitalgov.gov to connect-src to enable source map loading

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -85,7 +85,7 @@ http {
       resolver               8.8.8.8 valid=300s;
 
       add_header             Cache-Control "no-cache";
-      add_header             Content-Security-Policy "default-src 'self'; script-src 'self' https://dap.digitalgov.gov https://www.googletagmanager.com https://touchpoints.app.cloud.gov; connect-src 'self' https://www.google-analytics.com https://touchpoints.app.cloud.gov; img-src 'self' https://touchpoints.app.cloud.gov https://cg-1b082c1b-3db7-477f-9ca5-bd51a786b41e.s3-us-gov-west-1.amazonaws.com; form-action https://www.google.com; frame-ancestors 'none';" always;
+      add_header             Content-Security-Policy "default-src 'self'; script-src 'self' https://dap.digitalgov.gov https://www.googletagmanager.com https://touchpoints.app.cloud.gov; connect-src 'self' https://dap.digitalgov.gov https://www.google-analytics.com https://touchpoints.app.cloud.gov; img-src 'self' https://touchpoints.app.cloud.gov https://cg-1b082c1b-3db7-477f-9ca5-bd51a786b41e.s3-us-gov-west-1.amazonaws.com; form-action https://www.google.com; frame-ancestors 'none';" always;
       add_header             Permissions-Policy "autoplay=(), encrypted-media=(), fullscreen=(), geolocation=(), microphone=(), midi=(), payment=()" always;
       add_header             Pragma "no-cache";
       add_header             Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
@@ -114,7 +114,7 @@ http {
       # Touchpoints and S3 domains are added to the CSP support touchpoints JS
       # code which dynamically adds HTML with images and references JS on the
       # touchpoints server.
-      add_header Content-Security-Policy "default-src 'self'; script-src 'self' https://dap.digitalgov.gov https://www.googletagmanager.com https://touchpoints.app.cloud.gov; connect-src 'self' https://www.google-analytics.com https://touchpoints.app.cloud.gov; img-src 'self' https://touchpoints.app.cloud.gov https://cg-1b082c1b-3db7-477f-9ca5-bd51a786b41e.s3-us-gov-west-1.amazonaws.com; form-action https://www.google.com; frame-ancestors 'none';" always;
+      add_header Content-Security-Policy "default-src 'self'; script-src 'self' https://dap.digitalgov.gov https://www.googletagmanager.com https://touchpoints.app.cloud.gov; connect-src 'self' https://dap.digitalgov.gov https://www.google-analytics.com https://touchpoints.app.cloud.gov; img-src 'self' https://touchpoints.app.cloud.gov https://cg-1b082c1b-3db7-477f-9ca5-bd51a786b41e.s3-us-gov-west-1.amazonaws.com; form-action https://www.google.com; frame-ancestors 'none';" always;
       add_header Permissions-Policy "autoplay=(), encrypted-media=(), fullscreen=(), geolocation=(), microphone=(), midi=(), payment=()" always;
       add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
       add_header X-Content-Type-Options "nosniff" always;
@@ -122,7 +122,7 @@ http {
     }
 
     location =/developers {
-      add_header Content-Security-Policy "default-src 'self'; script-src 'self' https://dap.digitalgov.gov https://www.googletagmanager.com https://touchpoints.app.cloud.gov; connect-src 'self' https://www.google-analytics.com https://touchpoints.app.cloud.gov; img-src 'self' https://touchpoints.app.cloud.gov https://cg-1b082c1b-3db7-477f-9ca5-bd51a786b41e.s3-us-gov-west-1.amazonaws.com; form-action 'none'; frame-ancestors 'none';" always;
+      add_header Content-Security-Policy "default-src 'self'; script-src 'self' https://dap.digitalgov.gov https://www.googletagmanager.com https://touchpoints.app.cloud.gov; connect-src 'self' https://dap.digitalgov.gov https://www.google-analytics.com https://touchpoints.app.cloud.gov; img-src 'self' https://touchpoints.app.cloud.gov https://cg-1b082c1b-3db7-477f-9ca5-bd51a786b41e.s3-us-gov-west-1.amazonaws.com; form-action https://www.google.com; frame-ancestors 'none';" always;
       add_header Permissions-Policy "autoplay=(), encrypted-media=(), fullscreen=(), geolocation=(), microphone=(), midi=(), payment=()" always;
       add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
       add_header X-Content-Type-Options "nosniff" always;
@@ -130,7 +130,7 @@ http {
     }
 
     location =/developer {
-      add_header Content-Security-Policy "default-src 'self'; script-src 'self' https://dap.digitalgov.gov https://www.googletagmanager.com https://touchpoints.app.cloud.gov; connect-src 'self' https://www.google-analytics.com https://touchpoints.app.cloud.gov; img-src 'self' https://touchpoints.app.cloud.gov https://cg-1b082c1b-3db7-477f-9ca5-bd51a786b41e.s3-us-gov-west-1.amazonaws.com; form-action 'none'; frame-ancestors 'none';" always;
+      add_header Content-Security-Policy "default-src 'self'; script-src 'self' https://dap.digitalgov.gov https://www.googletagmanager.com https://touchpoints.app.cloud.gov; connect-src 'self' https://dap.digitalgov.gov https://www.google-analytics.com https://touchpoints.app.cloud.gov; img-src 'self' https://touchpoints.app.cloud.gov https://cg-1b082c1b-3db7-477f-9ca5-bd51a786b41e.s3-us-gov-west-1.amazonaws.com; form-action https://www.google.com; frame-ancestors 'none';" always;
       add_header Permissions-Policy "autoplay=(), encrypted-media=(), fullscreen=(), geolocation=(), microphone=(), midi=(), payment=()" always;
       add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
       add_header X-Content-Type-Options "nosniff" always;


### PR DESCRIPTION
Testing on staging revealed that the DAP code source map doesn't load in Chrome with the current CSP.

<img width="1423" height="58" alt="Screenshot 2026-05-07 at 10 50 11 AM" src="https://github.com/user-attachments/assets/97662d64-897d-4081-851e-c2da9f8643a0" />


Most DAP-enabled sites don't need to load the DAP code source map but we sometimes use https://analytics.usa.gov as a testing ground for the DAP code.