### PR TITLE
Rename Food and Nutrition Service to Food and Nutrition Administration

### DIFF
--- a/_data/agencies.json
+++ b/_data/agencies.json
@@ -69,7 +69,7 @@
     "api_v1": true
   },
   {
-    "name": "Food and Nutrition Service",
+    "name": "Food and Nutrition Administration",
     "slug": "food-nutrition-service",
     "redirect_from": [
       "fns"


### PR DESCRIPTION
The agency has changed its name and a member of their web team asked that we update the name in https://analytics.usa.gov/.