### PR TITLE
Security: Potential Cross-Site Scripting (XSS) via HTML Attribute Injection

### DIFF
--- a/_includes/historical_data_download.html
+++ b/_includes/historical_data_download.html
@@ -13,6 +13,6 @@
     id="historical-data-download-root"
     apiURL="{{ site.api_url }}"
     mainAgencyName="{{ site.dropdown_title }}"
-    agencies='{{ site.data.agencies | jsonify }}'
+    agencies="{{ site.data.agencies | jsonify | xml_escape }}"
   ></div>
 </main>


### PR DESCRIPTION
## Summary

Security: Potential Cross-Site Scripting (XSS) via HTML Attribute Injection

## Problem

**Severity**: `Medium` | **File**: `_includes/historical_data_download.html:L10`

In _includes/footer.html, the site.baseurl is interpolated into an HTML attribute without explicit escaping. While Jekyll typically escapes output by default, the use of double quotes around the attribute value relies on proper escaping. If site.baseurl ever contains malicious content or if the template engine's escaping behavior changes, this could lead to attribute injection. More critically, in _includes/historical_data_download.html and _includes/visualizations.html, the agencies data is passed via JSON through Jekyll's jsonify filter into HTML attributes using single quotes. The jsonify filter may not sufficiently escape content for HTML attribute contexts, particularly if agency names contain single quotes or other special characters, potentially breaking out of the attribute context and enabling XSS.

## Solution

Ensure all dynamic content inserted into HTML attributes is properly escaped for the HTML attribute context. Consider using data-* attributes with URL-encoded or base64-encoded JSON, or ensure the jsonify filter properly escapes single quotes and other HTML-sensitive characters. Add explicit HTML escaping where Jekyll's default escaping might be bypassed.

## Changes

- `_includes/historical_data_download.html` (modified)